### PR TITLE
Allowing DateTimeField to accept empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v4.0.8
+### Fixed
+- DateTimeField accepts empty string and renders placeholder.
+
 ## v4.0.7
 ### Fixed
 - InlinePopup should be disableable

--- a/lib/components/DateTime/DateTimeField.md
+++ b/lib/components/DateTime/DateTimeField.md
@@ -153,3 +153,18 @@ const initialState = {value: 'Sep 20, 2010 05:00:00 GMT'};
     />
 </div>
 ```
+
+```jsx
+const initialValue = '';
+const initialState = {value: ''};
+
+<div>
+    <div>Current Value: {state.value}</div>
+    <DatePicker
+        name='date-picker'
+        onChange={(newValue) => setState({value: newValue}) }
+        initialValue={initialValue}
+        localTimezone={false}
+    />
+</div>
+```

--- a/lib/components/DateTime/DateTimeField.md
+++ b/lib/components/DateTime/DateTimeField.md
@@ -155,16 +155,17 @@ const initialState = {value: 'Sep 20, 2010 05:00:00 GMT'};
 ```
 
 ```jsx
-const initialValue = '';
 const initialState = {value: ''};
 
 <div>
-    <div>Current Value: {state.value}</div>
-    <DatePicker
-        name='date-picker'
-        onChange={(newValue) => setState({value: newValue}) }
-        initialValue={initialValue}
+        <div style={{marginBottom: '20px'}}>Current Value: {state.value}</div>
+    <DateTimeField
+        name='date-picker-disabled'
+        initialValue={''}
+        label='Empty string example (GMT)'
+        error={state.value === 'invalid' ? 'This must be a valid date and time!' : ''}
         localTimezone={false}
+        onChange={(newValue) => setState({value: newValue})}
     />
 </div>
 ```

--- a/lib/components/DateTime/DateTimeField.tsx
+++ b/lib/components/DateTime/DateTimeField.tsx
@@ -139,7 +139,7 @@ export class DateTimeField extends React.Component<DateTimeFieldProps, Partial<D
         const local = props.localTimezone;
         let invalid = false;
         let initialValue = null;
-        if (props.initialValue) {
+        if (props.initialValue || props.initialValue === '') {
             if (typeof props.initialValue === 'string') {
                 const date = new Date(props.initialValue);
                 if (dateIsValid(date, local)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "4.0.7",
+    "version": "4.0.8",
     "description": "Azure IoT Fluent React Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",


### PR DESCRIPTION
Initially, if DateTimeField recieived an empty string, it would incorrectly try to parse it into JSON causing browser error. This change allows the 'invalid' flag to be set when an empty string is passed, which causes the empty string to be set in the state. 