### PR TITLE
Built-in browser input validation & NumberInput validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v4.0.8
+### Fixed
+- Handling built-in browser validation for inputs
+- Handling dash and period in number inputs
+
 ## v4.0.7
 ### Fixed
 - InlinePopup should be disableable

--- a/lib/components/Input/NumberInput.tsx
+++ b/lib/components/Input/NumberInput.tsx
@@ -111,7 +111,6 @@ export class NumberInput extends React.Component<NumberInputProps, NumberInputSt
             !this.isPositive()
             /** Firefox uses a different keycode for dashes (-) than other browsers... */
             && (event.keyCode === keyCode.dash || event.keyCode === keyCode.firefoxDash)
-            && this.state.value.indexOf('-') === -1
         ) {
             return;
         }
@@ -119,7 +118,6 @@ export class NumberInput extends React.Component<NumberInputProps, NumberInputSt
         if (
             !this.isInteger()
             && event.keyCode === keyCode.period
-            && this.state.value.indexOf('.') === -1
         ) {
             return;
         }

--- a/lib/components/Input/TextInput.tsx
+++ b/lib/components/Input/TextInput.tsx
@@ -88,6 +88,7 @@ export class TextInput extends React.PureComponent<TextInputProps> {
     constructor(props: TextInputProps) {
         super(props);
         this.onChange = this.onChange.bind(this);
+        this.onBlur = this.onBlur.bind(this);
         this.onClear = this.onClear.bind(this);
     }
 
@@ -97,6 +98,19 @@ export class TextInput extends React.PureComponent<TextInputProps> {
             this.props.onChange(targetValue);
         }
         event.stopPropagation();
+    }
+
+    onBlur(event: React.SyntheticEvent<HTMLInputElement>) {
+        const target = (event.target as HTMLInputElement);
+
+        // Bad inputs won't trigger 'onChange', so we clean the field to avoid losing track of the value
+        if (this.props.type === 'number' && target.validity.badInput) {
+            target.value = '';
+
+            if (this.props.value !== target.value) {
+                this.props.onChange(target.value);
+            }
+        }
     }
 
     onClear() {
@@ -154,6 +168,7 @@ export class TextInput extends React.PureComponent<TextInputProps> {
                         value={this.props.value == null ? '' : this.props.value}
                         className={inputClassName}
                         onChange={this.onChange}
+                        onBlur={this.onBlur}
                         placeholder={this.props.placeholder}
                         required={this.props.required}
                         disabled={this.props.disabled}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "4.0.7",
+    "version": "4.0.8",
     "description": "Azure IoT Fluent React Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "4.0.8",
+    "version": "4.0.9",
     "description": "Azure IoT Fluent React Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",


### PR DESCRIPTION
`onchange` events are not triggered for bad inputs, which caused our TextInput component to lose track of the input value whenever the value entered by the user did not match the input type. One of the side effects is that a user can add an arbitrary number of dashes and periods to number fields.

In the NumberInput side, our validation for `onkeydown` relied on the component state having the most recent value, which is not true until `onchange` triggers for a valid input value, thus the checks to avoid multiple periods and dashes did not work in most cases.