### PR TITLE
Remove webpack includePath dependency

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 dist/
 docs/
+test/
 method-design/
 .sass-lint.yml
 karma.conf.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## v5.0.0
+### Changed
+- Dependency on a `_colors.scss` existing at the global scope (resolved via webpack `includePath`).
+
+  The controls library now requires the file to exist at `<project root>/src/styles/_colors.scss`. This convention allows the library to be used with an out-of-the-box [create-react-app](https://github.com/facebook/create-react-app) install without ejecting. See the [Azure IoT UX Baseline](https://github.com/Azure/iot-ux-baseline) for an example.
+
+  For ease of use, this file will be automatically created on postinstall if it doesn't already exist.
+
+
 ## v4.0.9
 ### Fixed
 - Calendar component would choose current time first time you are selecting a date. Now defaults to 12:00 AM local

--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ This project contains common React controls (Form Inputs, DateTime etc.) that ma
 npm install --save @microsoft/azure-iot-ux-fluent-controls
 ```
 
+This project is built on top of [Azure IoT UX Fluent CSS](https://github.com/Azure/iot-ux-fluent-css) and expects it -- along a few other common packages like React -- to be present in your app as peer dependencies. Run the following command to install these:
+```
+npm install --save @microsoft/azure-iot-ux-fluent-css react react-dom classnames prop-types
+```
+
+On install, this project will create a `_colors.scss` file at your `<app root>/src/styles/`. This allows you to override or extend the default colors specified in the CSS library and have it apply to the controls seamlessly. For more details, see the comments and examples in `_colors.scss`.
+
+
 # Quick overview
 The full documentation and sample code for the controls is available at https://aka.ms/iotfluentcontrols, but in general, the pattern is:
 
@@ -44,7 +52,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 
 ## Build
-1. git clone https://github.com/Azure/iot-react-controls.git
+1. git clone https://github.com/Azure/iot-ux-fluent-controls.git
 2. npm install
 3. npm run build
 
@@ -52,11 +60,9 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 1. npm run docs:build
 2. npm run docs
 3. You can now view style guide in the browser:
-
-    - `On Local:`         http://localhost:6060/
-
-    - `On your network:`  http://{machine ip address}:6060/
+    - On local:         http://localhost:6060/
+    - On your network:  http://{machine ip address}:6060/
 
 ## Bug/ Issue
 
-https://github.com/Azure/iot-react-controls/issues
+https://github.com/Azure/iot-ux-fluent-controls/issues

--- a/README.md
+++ b/README.md
@@ -1,4 +1,32 @@
-# Azure IoT React Controls
+# Azure IoT UX Fluent Controls
+
+This project contains common React controls (Form Inputs, DateTime etc.) that match the Azure IoT Fluent design.
+
+# Get started
+```
+npm install --save @microsoft/azure-iot-ux-fluent-controls
+```
+
+# Quick overview
+The full documentation and sample code for the controls is available at https://aka.ms/iotfluentcontrols, but in general, the pattern is:
+
+```tsx
+import { DateField } from '@microsoft/azure-iot-ux-fluent-controls';
+const initialState = {value: 'Sep 20, 2010 07:00:00 GMT'};
+
+<div>
+    <div style={{marginBottom: '20px'}}>
+        Current Value: {state.value}
+    </div>
+    <DateField
+        name='date-picker'
+        label='Default Example (Local)'
+        onChange={(newValue) => setState({value: newValue}) }
+        initialValue={state.value}
+    />
+</div>
+```
+![Image of DateField control](https://i.imgur.com/KAT2EBf.jpg)
 
 ## Contributing
 

--- a/lib/common/_color.controls.scss
+++ b/lib/common/_color.controls.scss
@@ -1,15 +1,7 @@
-// The 'colors' file is injected by webpack during build time. The following snippet inside
-// the webpack.config specifies the location of the file:
-//
-//   {
-//      loader: 'sass-loader',
-//      options: {
-//          includePaths: path.resolve(`./template/src/styles`)
-//      }
-//   }
-//
-// This will import './template/src/styles/colors' to be available as 'colors'. This allows
-// the app to specify one color override file for both the controls and the app. Please
-// see https://github.com/webpack-contrib/sass-loader for further documentation.
-
+// Import the colors specified at <project root>/src/styles/_colors.scss.
+// This allows each project to override or extend the colors specified in
+// @microsoft/azure-iot-ux-fluent-css and have it apply to the controls seamlessly.
+// If we take a direct dependency on the css library here, the per-project
+// customization won't be reflected in the controls.
+// To access the project root, start from '~' (the node_modules folder) and move up:
 @import '~/../src/styles/colors';

--- a/lib/common/_color.controls.scss
+++ b/lib/common/_color.controls.scss
@@ -8,8 +8,8 @@
 //      }
 //   }
 //
-// This will import './template/src/styles/colors' to be available as 'colors'. This allows 
+// This will import './template/src/styles/colors' to be available as 'colors'. This allows
 // the app to specify one color override file for both the controls and the app. Please
 // see https://github.com/webpack-contrib/sass-loader for further documentation.
 
-@import 'colors';
+@import '~/../src/styles/colors';

--- a/lib/components/Shell/Shell.scss
+++ b/lib/components/Shell/Shell.scss
@@ -1,6 +1,6 @@
 @import "~@microsoft/azure-iot-ux-fluent-css/src/normalize";
 @import "~@microsoft/azure-iot-ux-fluent-css/src/icons";
-@import "colors";
+@import '../../common/color.controls';
 
 // provide some common styling that everyone requires:
 :global {

--- a/lib/scripts/postinstall.ts
+++ b/lib/scripts/postinstall.ts
@@ -1,0 +1,38 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as process from 'process';
+import * as util from 'util';
+
+declare const __dirname: string;
+
+const access = util.promisify(fs.access);
+const copyFile = util.promisify(fs.copyFile);
+const mkdir = util.promisify(fs.mkdir);
+
+async function notExists(p: string) {
+    try {
+        await access(p);
+        return false;
+    } catch (err) {
+        return true;
+    }
+}
+
+async function main() {
+    if (await notExists('./src/')) {
+        await mkdir('./src/');
+    }
+
+    if (await notExists('./src/styles/')) {
+        await mkdir('./src/styles/');
+    }
+
+    if (await notExists('./src/styles/_colors.scss')) {
+        await copyFile(path.resolve(__dirname, '../../src/styles/_colors.scss'), './src/styles/_colors.scss');
+    }
+}
+
+main().catch(err => {
+    console.error(err);
+    process.exit(-1);
+});

--- a/lib/scripts/postinstall.ts
+++ b/lib/scripts/postinstall.ts
@@ -19,16 +19,20 @@ async function notExists(p: string) {
 }
 
 async function main() {
-    if (await notExists('./src/')) {
-        await mkdir('./src/');
+    const projectRoot = process.env.INIT_CWD;
+    const srcFolder = path.resolve(projectRoot, 'src');
+    if (await notExists(srcFolder)) {
+        await mkdir(srcFolder);
     }
 
-    if (await notExists('./src/styles/')) {
-        await mkdir('./src/styles/');
+    const srcStylesFolder = path.resolve(srcFolder, 'styles');
+    if (await notExists(srcStylesFolder)) {
+        await mkdir(srcStylesFolder);
     }
 
-    if (await notExists('./src/styles/_colors.scss')) {
-        await copyFile(path.resolve(__dirname, '../../src/styles/_colors.scss'), './src/styles/_colors.scss');
+    const srcStylesColorsFile = path.resolve(srcStylesFolder, '_colors.scss');
+    if (await notExists(srcStylesColorsFile)) {
+        await copyFile(path.resolve(__dirname, '../../src/styles/_colors.scss'), srcStylesColorsFile);
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "5.0.0-alpha.1",
+    "version": "5.0.0-alpha.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "5.0.0-alpha.2",
+    "version": "5.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,14217 @@
+{
+    "name": "@microsoft/azure-iot-ux-fluent-controls",
+    "version": "5.0.0-alpha.1",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+            "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.0.0"
+            }
+        },
+        "@babel/generator": {
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.6.tgz",
+            "integrity": "sha512-brwPBtVvdYdGxtenbQgfCdDPmtkmUBZPjUoK5SXJEBuHaA5BCubh9ly65fzXz7R6o5rA76Rs22ES8Z+HCc0YIQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.1.6",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.10",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
+            },
+            "dependencies": {
+                "jsesc": {
+                    "version": "2.5.2",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+            "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-get-function-arity": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+            "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+            "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+            "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
+            },
+            "dependencies": {
+                "js-tokens": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/parser": {
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.6.tgz",
+            "integrity": "sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ==",
+            "dev": true
+        },
+        "@babel/template": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
+            "integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.1.2",
+                "@babel/types": "^7.1.2"
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.6.tgz",
+            "integrity": "sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.1.6",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "@babel/parser": "^7.1.6",
+                "@babel/types": "^7.1.6",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.10"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+                    "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "globals": {
+                    "version": "11.9.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
+                    "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/types": {
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.6.tgz",
+            "integrity": "sha512-DMiUzlY9DSjVsOylJssxLHSgj6tWM9PRFJOGW/RaOglVOK9nzTxoOMfTfRQXGUCUQ/HmlG2efwC+XqUEJ5ay4w==",
+            "dev": true,
+            "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.10",
+                "to-fast-properties": "^2.0.0"
+            },
+            "dependencies": {
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "@microsoft/azure-iot-ux-fluent-css": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/azure-iot-ux-fluent-css/-/azure-iot-ux-fluent-css-4.0.0.tgz",
+            "integrity": "sha512-WQUJiCcC3BuUiyxz2Pr/yxRpiKvG1EfwIeqXSUe8XBjF3GloifanoqiAtsY4X0xDpuP30mr1mqZdlghHJPZyzQ==",
+            "dev": true
+        },
+        "@sinonjs/commons": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+            "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+            "dev": true,
+            "requires": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "@sinonjs/formatio": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
+            "integrity": "sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/samsam": "2.1.0"
+            },
+            "dependencies": {
+                "@sinonjs/samsam": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz",
+                    "integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
+                    "dev": true,
+                    "requires": {
+                        "array-from": "^2.1.1"
+                    }
+                }
+            }
+        },
+        "@sinonjs/samsam": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.2.tgz",
+            "integrity": "sha512-ZwTHAlC9akprWDinwEPD4kOuwaYZlyMwVJIANsKNC3QVp0AHB04m7RnB4eqeWfgmxw8MGTzS9uMaw93Z3QcZbw==",
+            "dev": true
+        },
+        "@types/chai": {
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
+            "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
+            "dev": true
+        },
+        "@types/cheerio": {
+            "version": "0.22.9",
+            "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.9.tgz",
+            "integrity": "sha512-q6LuBI0t5u04f0Q4/R+cGBqIbZMtJkVvCSF+nTfFBBdQqQvJR/mNHeWjRkszyLl7oyf2rDoKUYMEjTw5AV0hiw==",
+            "dev": true
+        },
+        "@types/classnames": {
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.6.tgz",
+            "integrity": "sha512-XHcYvVdbtAxVstjKxuULYqYaWIzHR15yr1pZj4fnGChuBVJlIAp9StJna0ZJNSgxPh4Nac2FL4JM3M11Tm6fqQ==",
+            "dev": true
+        },
+        "@types/enzyme": {
+            "version": "2.8.12",
+            "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-2.8.12.tgz",
+            "integrity": "sha512-yiUV6c6f2heD1rnw5jQjRNrszS1fEFLWorrMGa3CKfCLI/a6eInzHuTrlT6GzFq8HbzdRYUeYXABNP1QKMDVLQ==",
+            "dev": true,
+            "requires": {
+                "@types/cheerio": "*",
+                "@types/react": "*"
+            }
+        },
+        "@types/mocha": {
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.5.tgz",
+            "integrity": "sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww==",
+            "dev": true
+        },
+        "@types/node": {
+            "version": "8.10.38",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.38.tgz",
+            "integrity": "sha512-EibsnbJerd0hBFaDjJStFrVbVBAtOy4dgL8zZFw0uOvPqzBAX59Ci8cgjg3+RgJIWhsB5A4c+pi+D4P9tQQh/A==",
+            "dev": true
+        },
+        "@types/react": {
+            "version": "16.4.2",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.2.tgz",
+            "integrity": "sha512-oVcVteCDNiVc/fkDjowRfAZQDEOR76j3CJ3FvwXNvfV6zJguhghy1lMgpAzYox+9AZsWch+JPV6Imml3wvIUeg==",
+            "dev": true,
+            "requires": {
+                "csstype": "^2.2.0"
+            }
+        },
+        "@types/react-dom": {
+            "version": "16.0.9",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.0.9.tgz",
+            "integrity": "sha512-4Z0bW+75zeQgsEg7RaNuS1k9MKhci7oQqZXxrV5KUGIyXZHHAAL3KA4rjhdH8o6foZ5xsRMSqkoM5A3yRVPR5w==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*",
+                "@types/react": "*"
+            }
+        },
+        "@types/sinon": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-5.0.5.tgz",
+            "integrity": "sha512-Wnuv66VhvAD2LEJfZkq8jowXGxe+gjVibeLCYcVBp7QLdw0BFx2sRkKzoiiDkYEPGg5VyqO805Rcj0stVjQwCQ==",
+            "dev": true
+        },
+        "@types/webpack-env": {
+            "version": "1.13.6",
+            "resolved": "http://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.6.tgz",
+            "integrity": "sha512-5Th3OsZ4gTRdr9Mho83BQ23cex4sRhOR4XTG+m+cJc0FhtUBK9Vn62hBJ+pnQYnSxoPOsKoAPOx6FcphxBC8ng==",
+            "dev": true
+        },
+        "@vxna/mini-html-webpack-template": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/@vxna/mini-html-webpack-template/-/mini-html-webpack-template-0.1.7.tgz",
+            "integrity": "sha512-qV2VslV48ECPwyuG7c4O6JpYgjnvdm88YYkMncIXzakXXwVUxhcg6YipXxWK7U+pixHkWWSnDX/8DIOmWeh+PQ==",
+            "dev": true,
+            "requires": {
+                "common-tags": "^1.7.2"
+            }
+        },
+        "abab": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
+            "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
+            "dev": true
+        },
+        "abbrev": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+            "dev": true
+        },
+        "accepts": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+            "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+            "dev": true,
+            "requires": {
+                "mime-types": "~2.1.18",
+                "negotiator": "0.6.1"
+            }
+        },
+        "acorn": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
+            "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
+            "dev": true
+        },
+        "acorn-dynamic-import": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
+            "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
+            "dev": true,
+            "requires": {
+                "acorn": "^5.0.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.7.3",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+                    "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+                    "dev": true
+                }
+            }
+        },
+        "acorn-globals": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
+            "integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
+            "dev": true,
+            "requires": {
+                "acorn": "^6.0.1",
+                "acorn-walk": "^6.0.1"
+            }
+        },
+        "acorn-jsx": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
+            "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
+            "dev": true,
+            "requires": {
+                "acorn": "^5.0.3"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.7.3",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+                    "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+                    "dev": true
+                }
+            }
+        },
+        "acorn-walk": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+            "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
+            "dev": true
+        },
+        "address": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
+            "integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg==",
+            "dev": true
+        },
+        "ajv": {
+            "version": "6.5.5",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
+            "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+            "dev": true,
+            "requires": {
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
+        },
+        "ajv-keywords": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+            "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
+            "dev": true
+        },
+        "align-text": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+            "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "alphanum-sort": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+            "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
+            "dev": true
+        },
+        "amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+            "dev": true
+        },
+        "ansi-align": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+            "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+            "dev": true,
+            "requires": {
+                "string-width": "^2.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "ansi-escapes": {
+            "version": "3.1.0",
+            "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+            "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+            "dev": true
+        },
+        "ansi-html": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+            "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "requires": {
+                "color-convert": "^1.9.0"
+            }
+        },
+        "anymatch": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+            "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+            "dev": true,
+            "requires": {
+                "micromatch": "^3.1.4",
+                "normalize-path": "^2.1.1"
+            }
+        },
+        "aproba": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+            "dev": true
+        },
+        "are-we-there-yet": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+            "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+            "dev": true,
+            "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+            }
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "arr-diff": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+            "dev": true
+        },
+        "arr-flatten": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+            "dev": true
+        },
+        "arr-union": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+            "dev": true
+        },
+        "array-equal": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+            "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+            "dev": true
+        },
+        "array-filter": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+            "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+            "dev": true
+        },
+        "array-find-index": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+            "dev": true
+        },
+        "array-flatten": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
+            "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=",
+            "dev": true
+        },
+        "array-from": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+            "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+            "dev": true
+        },
+        "array-includes": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+            "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.7.0"
+            }
+        },
+        "array-map": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+            "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+            "dev": true
+        },
+        "array-reduce": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+            "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
+            "dev": true
+        },
+        "array-union": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+            "dev": true,
+            "requires": {
+                "array-uniq": "^1.0.1"
+            }
+        },
+        "array-uniq": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true
+        },
+        "array-unique": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+            "dev": true
+        },
+        "array.prototype.flat": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz",
+            "integrity": "sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.10.0",
+                "function-bind": "^1.1.1"
+            }
+        },
+        "arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+            "dev": true
+        },
+        "asn1": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": "~2.1.0"
+            }
+        },
+        "asn1.js": {
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+            "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
+            }
+        },
+        "assert": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+            "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+            "dev": true,
+            "requires": {
+                "util": "0.10.3"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                    "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                    "dev": true
+                },
+                "util": {
+                    "version": "0.10.3",
+                    "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+                    "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.1"
+                    }
+                }
+            }
+        },
+        "assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "dev": true
+        },
+        "assertion-error": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+            "dev": true
+        },
+        "assign-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+            "dev": true
+        },
+        "ast-types": {
+            "version": "0.11.6",
+            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.6.tgz",
+            "integrity": "sha512-nHiuV14upVGl7MWwFUYbzJ6YlfwWS084CU9EA8HajfYQjMSli5TQi3UTRygGF58LFWVkXxS1rbgRhROEqlQkXg==",
+            "dev": true
+        },
+        "async": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+            "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.10"
+            }
+        },
+        "async-each": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+            "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+            "dev": true
+        },
+        "async-foreach": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+            "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
+            "dev": true
+        },
+        "async-limiter": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+            "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+            "dev": true
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
+        },
+        "atob": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+            "dev": true
+        },
+        "autoprefixer": {
+            "version": "6.7.7",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+            "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+            "dev": true,
+            "requires": {
+                "browserslist": "^1.7.6",
+                "caniuse-db": "^1.0.30000634",
+                "normalize-range": "^0.1.2",
+                "num2fraction": "^1.2.2",
+                "postcss": "^5.2.16",
+                "postcss-value-parser": "^3.2.3"
+            }
+        },
+        "awesome-typescript-loader": {
+            "version": "3.5.0",
+            "resolved": "http://registry.npmjs.org/awesome-typescript-loader/-/awesome-typescript-loader-3.5.0.tgz",
+            "integrity": "sha512-qzgm9SEvodVkSi9QY7Me1/rujg+YBNMjayNSAyzNghwTEez++gXoPCwMvpbHRG7wrOkDCiF6dquvv9ESmUBAuw==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.3.1",
+                "enhanced-resolve": "3.3.0",
+                "loader-utils": "^1.1.0",
+                "lodash": "^4.17.4",
+                "micromatch": "^3.0.3",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.5.3"
+            }
+        },
+        "aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "dev": true
+        },
+        "aws4": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+            "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+            "dev": true
+        },
+        "babel-code-frame": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "babel-core": {
+            "version": "6.26.3",
+            "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+            "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+            "dev": true,
+            "requires": {
+                "babel-code-frame": "^6.26.0",
+                "babel-generator": "^6.26.0",
+                "babel-helpers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-register": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "convert-source-map": "^1.5.1",
+                "debug": "^2.6.9",
+                "json5": "^0.5.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.4",
+                "path-is-absolute": "^1.0.1",
+                "private": "^0.1.8",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.7"
+            }
+        },
+        "babel-generator": {
+            "version": "6.26.1",
+            "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+            "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+            "dev": true,
+            "requires": {
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "detect-indent": "^4.0.0",
+                "jsesc": "^1.3.0",
+                "lodash": "^4.17.4",
+                "source-map": "^0.5.7",
+                "trim-right": "^1.0.1"
+            }
+        },
+        "babel-helper-call-delegate": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+            "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+            "dev": true,
+            "requires": {
+                "babel-helper-hoist-variables": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-helper-define-map": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+            "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+            "dev": true,
+            "requires": {
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
+            }
+        },
+        "babel-helper-function-name": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+            "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+            "dev": true,
+            "requires": {
+                "babel-helper-get-function-arity": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-helper-get-function-arity": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+            "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-helper-hoist-variables": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+            "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-helper-optimise-call-expression": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+            "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-helper-regex": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+            "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
+            }
+        },
+        "babel-helper-replace-supers": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+            "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+            "dev": true,
+            "requires": {
+                "babel-helper-optimise-call-expression": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-helpers": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+            "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
+            }
+        },
+        "babel-loader": {
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.5.tgz",
+            "integrity": "sha512-iCHfbieL5d1LfOQeeVJEUyD9rTwBcP/fcEbRCfempxTDuqrKpu0AZjLAQHEQa3Yqyj9ORKe2iHfoj4rHLf7xpw==",
+            "dev": true,
+            "requires": {
+                "find-cache-dir": "^1.0.0",
+                "loader-utils": "^1.0.2",
+                "mkdirp": "^0.5.1"
+            }
+        },
+        "babel-messages": {
+            "version": "6.23.0",
+            "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+            "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-check-es2015-constants": {
+            "version": "6.22.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+            "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-arrow-functions": {
+            "version": "6.22.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+            "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-block-scoped-functions": {
+            "version": "6.22.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+            "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-block-scoping": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+            "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
+            }
+        },
+        "babel-plugin-transform-es2015-classes": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+            "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+            "dev": true,
+            "requires": {
+                "babel-helper-define-map": "^6.24.1",
+                "babel-helper-function-name": "^6.24.1",
+                "babel-helper-optimise-call-expression": "^6.24.1",
+                "babel-helper-replace-supers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-computed-properties": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+            "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-destructuring": {
+            "version": "6.23.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+            "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-duplicate-keys": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+            "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-for-of": {
+            "version": "6.23.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+            "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-function-name": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+            "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+            "dev": true,
+            "requires": {
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-literals": {
+            "version": "6.22.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+            "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-modules-amd": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+            "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+            "dev": true,
+            "requires": {
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-modules-commonjs": {
+            "version": "6.26.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+            "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+            "dev": true,
+            "requires": {
+                "babel-plugin-transform-strict-mode": "^6.24.1",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-types": "^6.26.0"
+            }
+        },
+        "babel-plugin-transform-es2015-modules-systemjs": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+            "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+            "dev": true,
+            "requires": {
+                "babel-helper-hoist-variables": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-modules-umd": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+            "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+            "dev": true,
+            "requires": {
+                "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-object-super": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+            "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+            "dev": true,
+            "requires": {
+                "babel-helper-replace-supers": "^6.24.1",
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-parameters": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+            "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+            "dev": true,
+            "requires": {
+                "babel-helper-call-delegate": "^6.24.1",
+                "babel-helper-get-function-arity": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-shorthand-properties": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+            "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-spread": {
+            "version": "6.22.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+            "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-sticky-regex": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+            "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+            "dev": true,
+            "requires": {
+                "babel-helper-regex": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-template-literals": {
+            "version": "6.22.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+            "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-typeof-symbol": {
+            "version": "6.23.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+            "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-unicode-regex": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+            "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+            "dev": true,
+            "requires": {
+                "babel-helper-regex": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "regexpu-core": "^2.0.0"
+            }
+        },
+        "babel-plugin-transform-regenerator": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+            "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+            "dev": true,
+            "requires": {
+                "regenerator-transform": "^0.10.0"
+            }
+        },
+        "babel-plugin-transform-strict-mode": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+            "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-preset-es2015": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+            "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+            "dev": true,
+            "requires": {
+                "babel-plugin-check-es2015-constants": "^6.22.0",
+                "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+                "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+                "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+                "babel-plugin-transform-es2015-classes": "^6.24.1",
+                "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+                "babel-plugin-transform-es2015-destructuring": "^6.22.0",
+                "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+                "babel-plugin-transform-es2015-for-of": "^6.22.0",
+                "babel-plugin-transform-es2015-function-name": "^6.24.1",
+                "babel-plugin-transform-es2015-literals": "^6.22.0",
+                "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+                "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+                "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+                "babel-plugin-transform-es2015-object-super": "^6.24.1",
+                "babel-plugin-transform-es2015-parameters": "^6.24.1",
+                "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+                "babel-plugin-transform-es2015-spread": "^6.22.0",
+                "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+                "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+                "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+                "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+                "babel-plugin-transform-regenerator": "^6.24.1"
+            }
+        },
+        "babel-register": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+            "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+            "dev": true,
+            "requires": {
+                "babel-core": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "core-js": "^2.5.0",
+                "home-or-tmp": "^2.0.0",
+                "lodash": "^4.17.4",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.4.15"
+            },
+            "dependencies": {
+                "source-map-support": {
+                    "version": "0.4.18",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+                    "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+                    "dev": true,
+                    "requires": {
+                        "source-map": "^0.5.6"
+                    }
+                }
+            }
+        },
+        "babel-runtime": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+            "dev": true,
+            "requires": {
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
+            }
+        },
+        "babel-template": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+            "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "lodash": "^4.17.4"
+            }
+        },
+        "babel-traverse": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+            "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+            "dev": true,
+            "requires": {
+                "babel-code-frame": "^6.26.0",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "debug": "^2.6.8",
+                "globals": "^9.18.0",
+                "invariant": "^2.2.2",
+                "lodash": "^4.17.4"
+            }
+        },
+        "babel-types": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+            "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.26.0",
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.4",
+                "to-fast-properties": "^1.0.3"
+            }
+        },
+        "babylon": {
+            "version": "6.18.0",
+            "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+            "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+            "dev": true
+        },
+        "bail": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
+            "integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg==",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "base": {
+            "version": "0.11.2",
+            "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+            "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+            "dev": true,
+            "requires": {
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "base64-js": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+            "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+            "dev": true
+        },
+        "batch": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+            "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+            "dev": true
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "dev": true,
+            "requires": {
+                "tweetnacl": "^0.14.3"
+            }
+        },
+        "big.js": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+            "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+            "dev": true
+        },
+        "binary-extensions": {
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
+            "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
+            "dev": true
+        },
+        "block-stream": {
+            "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+            "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+            "dev": true,
+            "requires": {
+                "inherits": "~2.0.0"
+            }
+        },
+        "bluebird": {
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+            "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+            "dev": true
+        },
+        "bn.js": {
+            "version": "4.11.8",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+            "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+            "dev": true
+        },
+        "body-parser": {
+            "version": "1.18.3",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+            "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+            "dev": true,
+            "requires": {
+                "bytes": "3.0.0",
+                "content-type": "~1.0.4",
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "http-errors": "~1.6.3",
+                "iconv-lite": "0.4.23",
+                "on-finished": "~2.3.0",
+                "qs": "6.5.2",
+                "raw-body": "2.3.3",
+                "type-is": "~1.6.16"
+            },
+            "dependencies": {
+                "iconv-lite": {
+                    "version": "0.4.23",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+                    "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+                    "dev": true,
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
+                }
+            }
+        },
+        "bonjour": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
+            "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+            "dev": true,
+            "requires": {
+                "array-flatten": "^2.1.0",
+                "deep-equal": "^1.0.1",
+                "dns-equal": "^1.0.0",
+                "dns-txt": "^2.0.2",
+                "multicast-dns": "^6.0.1",
+                "multicast-dns-service-types": "^1.1.0"
+            }
+        },
+        "boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+            "dev": true
+        },
+        "boxen": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+            "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+            "dev": true,
+            "requires": {
+                "ansi-align": "^2.0.0",
+                "camelcase": "^4.0.0",
+                "chalk": "^2.0.1",
+                "cli-boxes": "^1.0.0",
+                "string-width": "^2.0.0",
+                "term-size": "^1.2.0",
+                "widest-line": "^2.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "braces": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+            "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+            "dev": true,
+            "requires": {
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "brorand": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+            "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+            "dev": true
+        },
+        "browser-process-hrtime": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+            "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+            "dev": true
+        },
+        "browser-stdout": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+            "dev": true
+        },
+        "browserify-aes": {
+            "version": "1.2.0",
+            "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+            "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+            "dev": true,
+            "requires": {
+                "buffer-xor": "^1.0.3",
+                "cipher-base": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.3",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "browserify-cipher": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+            "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+            "dev": true,
+            "requires": {
+                "browserify-aes": "^1.0.4",
+                "browserify-des": "^1.0.0",
+                "evp_bytestokey": "^1.0.0"
+            }
+        },
+        "browserify-des": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+            "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+            "dev": true,
+            "requires": {
+                "cipher-base": "^1.0.1",
+                "des.js": "^1.0.0",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            }
+        },
+        "browserify-rsa": {
+            "version": "4.0.1",
+            "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+            "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.1.0",
+                "randombytes": "^2.0.1"
+            }
+        },
+        "browserify-sign": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+            "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.1.1",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.2",
+                "elliptic": "^6.0.0",
+                "inherits": "^2.0.1",
+                "parse-asn1": "^5.0.0"
+            }
+        },
+        "browserify-zlib": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+            "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+            "dev": true,
+            "requires": {
+                "pako": "~1.0.5"
+            }
+        },
+        "browserslist": {
+            "version": "1.7.7",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+            "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+            "dev": true,
+            "requires": {
+                "caniuse-db": "^1.0.30000639",
+                "electron-to-chromium": "^1.2.7"
+            }
+        },
+        "buble": {
+            "version": "0.19.4",
+            "resolved": "https://registry.npmjs.org/buble/-/buble-0.19.4.tgz",
+            "integrity": "sha512-xaTfnWdx80TiajGDZoSYB17nEDqjGnVxeug5W7tvXIAMn61yMa5AfTuWu3F4nLL2Fv/hK8T6GktZvQ6yvPZMpA==",
+            "dev": true,
+            "requires": {
+                "acorn": "^5.4.1",
+                "acorn-dynamic-import": "^3.0.0",
+                "acorn-jsx": "^4.1.1",
+                "chalk": "^2.3.1",
+                "magic-string": "^0.22.4",
+                "minimist": "^1.2.0",
+                "os-homedir": "^1.0.1",
+                "regexpu-core": "^4.1.3",
+                "vlq": "^1.0.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.7.3",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+                    "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+                    "dev": true
+                },
+                "jsesc": {
+                    "version": "0.5.0",
+                    "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+                    "dev": true
+                },
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                },
+                "regexpu-core": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
+                    "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
+                    "dev": true,
+                    "requires": {
+                        "regenerate": "^1.4.0",
+                        "regenerate-unicode-properties": "^7.0.0",
+                        "regjsgen": "^0.4.0",
+                        "regjsparser": "^0.3.0",
+                        "unicode-match-property-ecmascript": "^1.0.4",
+                        "unicode-match-property-value-ecmascript": "^1.0.2"
+                    }
+                },
+                "regjsgen": {
+                    "version": "0.4.0",
+                    "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
+                    "integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==",
+                    "dev": true
+                },
+                "regjsparser": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
+                    "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
+                    "dev": true,
+                    "requires": {
+                        "jsesc": "~0.5.0"
+                    }
+                }
+            }
+        },
+        "buffer": {
+            "version": "4.9.1",
+            "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+            "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+            "dev": true,
+            "requires": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
+            }
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
+        },
+        "buffer-indexof": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+            "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
+            "dev": true
+        },
+        "buffer-xor": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+            "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+            "dev": true
+        },
+        "builtin-modules": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+            "dev": true
+        },
+        "builtin-status-codes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+            "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+            "dev": true
+        },
+        "bytes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+            "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+            "dev": true
+        },
+        "cacache": {
+            "version": "10.0.4",
+            "resolved": "http://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+            "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+            "dev": true,
+            "requires": {
+                "bluebird": "^3.5.1",
+                "chownr": "^1.0.1",
+                "glob": "^7.1.2",
+                "graceful-fs": "^4.1.11",
+                "lru-cache": "^4.1.1",
+                "mississippi": "^2.0.0",
+                "mkdirp": "^0.5.1",
+                "move-concurrently": "^1.0.1",
+                "promise-inflight": "^1.0.1",
+                "rimraf": "^2.6.2",
+                "ssri": "^5.2.4",
+                "unique-filename": "^1.1.0",
+                "y18n": "^4.0.0"
+            },
+            "dependencies": {
+                "y18n": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+                    "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+                    "dev": true
+                }
+            }
+        },
+        "cache-base": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+            "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+            "dev": true,
+            "requires": {
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
+            }
+        },
+        "caller-path": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+            "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+            "dev": true,
+            "requires": {
+                "callsites": "^0.2.0"
+            }
+        },
+        "callsites": {
+            "version": "0.2.0",
+            "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+            "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+            "dev": true
+        },
+        "camel-case": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+            "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+            "dev": true,
+            "requires": {
+                "no-case": "^2.2.0",
+                "upper-case": "^1.1.1"
+            }
+        },
+        "camelcase": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+            "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+            "dev": true
+        },
+        "camelcase-keys": {
+            "version": "2.1.0",
+            "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+            "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+            "dev": true,
+            "requires": {
+                "camelcase": "^2.0.0",
+                "map-obj": "^1.0.0"
+            }
+        },
+        "caniuse-api": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
+            "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
+            "dev": true,
+            "requires": {
+                "browserslist": "^1.3.6",
+                "caniuse-db": "^1.0.30000529",
+                "lodash.memoize": "^4.1.2",
+                "lodash.uniq": "^4.5.0"
+            }
+        },
+        "caniuse-db": {
+            "version": "1.0.30000909",
+            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000909.tgz",
+            "integrity": "sha512-uQ/L28utpeTyjvy7PQtGamXtfLYJrnTD3YewssFIEUfZGNRZgY8M2ttKUbTNmw5hjGfcd/NdnXXD1NBMB4P4Uw==",
+            "dev": true
+        },
+        "capture-stack-trace": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+            "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
+            "dev": true
+        },
+        "caseless": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "dev": true
+        },
+        "ccount": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.3.tgz",
+            "integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw==",
+            "dev": true
+        },
+        "center-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+            "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+            "dev": true,
+            "requires": {
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
+            }
+        },
+        "chai": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+            "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+            "dev": true,
+            "requires": {
+                "assertion-error": "^1.1.0",
+                "check-error": "^1.0.2",
+                "deep-eql": "^3.0.1",
+                "get-func-name": "^2.0.0",
+                "pathval": "^1.1.0",
+                "type-detect": "^4.0.5"
+            }
+        },
+        "chai-enzyme": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/chai-enzyme/-/chai-enzyme-0.8.0.tgz",
+            "integrity": "sha1-YJxVKh3NsJH0NeHigcxPIUmjO+E=",
+            "dev": true,
+            "requires": {
+                "html": "^1.0.0",
+                "react-element-to-jsx-string": "^5.0.0"
+            }
+        },
+        "chalk": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+            "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            }
+        },
+        "character-entities": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.2.tgz",
+            "integrity": "sha512-sMoHX6/nBiy3KKfC78dnEalnpn0Az0oSNvqUWYTtYrhRI5iUIYsROU48G+E+kMFQzqXaJ8kHJZ85n7y6/PHgwQ==",
+            "dev": true
+        },
+        "character-entities-html4": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.2.tgz",
+            "integrity": "sha512-sIrXwyna2+5b0eB9W149izTPJk/KkJTg6mEzDGibwBUkyH1SbDa+nf515Ppdi3MaH35lW0JFJDWeq9Luzes1Iw==",
+            "dev": true
+        },
+        "character-entities-legacy": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz",
+            "integrity": "sha512-9NB2VbXtXYWdXzqrvAHykE/f0QJxzaKIpZ5QzNZrrgQ7Iyxr2vnfS8fCBNVW9nUEZE0lo57nxKRqnzY/dKrwlA==",
+            "dev": true
+        },
+        "character-reference-invalid": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
+            "integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ==",
+            "dev": true
+        },
+        "chardet": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+            "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+            "dev": true
+        },
+        "check-error": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+            "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+            "dev": true
+        },
+        "cheerio": {
+            "version": "1.0.0-rc.2",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
+            "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+            "dev": true,
+            "requires": {
+                "css-select": "~1.2.0",
+                "dom-serializer": "~0.1.0",
+                "entities": "~1.1.1",
+                "htmlparser2": "^3.9.1",
+                "lodash": "^4.15.0",
+                "parse5": "^3.0.1"
+            }
+        },
+        "chokidar": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
+            "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+            "dev": true,
+            "requires": {
+                "anymatch": "^2.0.0",
+                "async-each": "^1.0.0",
+                "braces": "^2.3.0",
+                "fsevents": "^1.2.2",
+                "glob-parent": "^3.1.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^4.0.0",
+                "lodash.debounce": "^4.0.8",
+                "normalize-path": "^2.1.1",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0",
+                "upath": "^1.0.5"
+            }
+        },
+        "chownr": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+            "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+            "dev": true
+        },
+        "ci-info": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+            "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+            "dev": true
+        },
+        "cipher-base": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+            "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "circular-json": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+            "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+            "dev": true
+        },
+        "clap": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
+            "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.1.3"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "class-utils": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+            "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+            "dev": true,
+            "requires": {
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "classnames": {
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+            "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
+            "dev": true
+        },
+        "clean-css": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
+            "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+            "dev": true,
+            "requires": {
+                "source-map": "~0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "clean-webpack-plugin": {
+            "version": "0.1.19",
+            "resolved": "http://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-0.1.19.tgz",
+            "integrity": "sha512-M1Li5yLHECcN2MahoreuODul5LkjohJGFxLPTjl3j1ttKrF5rgjZET1SJduuqxLAuT1gAPOdkhg03qcaaU1KeA==",
+            "dev": true,
+            "requires": {
+                "rimraf": "^2.6.1"
+            }
+        },
+        "cli-boxes": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+            "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+            "dev": true
+        },
+        "cli-cursor": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+            "dev": true,
+            "requires": {
+                "restore-cursor": "^2.0.0"
+            }
+        },
+        "cli-spinners": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
+            "integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==",
+            "dev": true
+        },
+        "cli-width": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+            "dev": true
+        },
+        "clipboard-copy": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/clipboard-copy/-/clipboard-copy-2.0.1.tgz",
+            "integrity": "sha512-/JBr7ryeWwl2w33SRMYGfOZU5SWPVNtpB9oTxUzFp7olKKd2HM+cnhSMeETblJMnjgqtL581ncI/pcZX7o7Big==",
+            "dev": true
+        },
+        "cliui": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+            "dev": true,
+            "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
+            }
+        },
+        "clone": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+            "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+            "dev": true
+        },
+        "clone-deep": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-2.0.2.tgz",
+            "integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
+            "dev": true,
+            "requires": {
+                "for-own": "^1.0.0",
+                "is-plain-object": "^2.0.4",
+                "kind-of": "^6.0.0",
+                "shallow-clone": "^1.0.0"
+            },
+            "dependencies": {
+                "for-own": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+                    "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+                    "dev": true,
+                    "requires": {
+                        "for-in": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
+        },
+        "coa": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+            "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
+            "dev": true,
+            "requires": {
+                "q": "^1.1.2"
+            }
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
+        },
+        "codemirror": {
+            "version": "5.41.0",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.41.0.tgz",
+            "integrity": "sha512-mkCwbneCx2WHg1MNCYrI+8Zuq0KMMaZ5yTFpQlAZazy3yxME8bHcuSc9WUFzgPZ114WqWu1FIHlx8CavLzBDIg==",
+            "dev": true
+        },
+        "collapse-white-space": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.4.tgz",
+            "integrity": "sha512-YfQ1tAUZm561vpYD+5eyWN8+UsceQbSrqqlc/6zDY2gtAE+uZLSdkkovhnGpmCThsvKBFakq4EdY/FF93E8XIw==",
+            "dev": true
+        },
+        "collection-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+            "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+            "dev": true,
+            "requires": {
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
+            }
+        },
+        "color": {
+            "version": "0.11.4",
+            "resolved": "http://registry.npmjs.org/color/-/color-0.11.4.tgz",
+            "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+            "dev": true,
+            "requires": {
+                "clone": "^1.0.2",
+                "color-convert": "^1.3.0",
+                "color-string": "^0.3.0"
+            }
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "color-string": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+            "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+            "dev": true,
+            "requires": {
+                "color-name": "^1.0.0"
+            }
+        },
+        "colormin": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+            "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
+            "dev": true,
+            "requires": {
+                "color": "^0.11.0",
+                "css-color-names": "0.0.4",
+                "has": "^1.0.1"
+            }
+        },
+        "colors": {
+            "version": "1.1.2",
+            "resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+            "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+            "dev": true
+        },
+        "combined-stream": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+            "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+            "dev": true,
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
+        },
+        "commander": {
+            "version": "2.17.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+            "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+            "dev": true
+        },
+        "common-dir": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/common-dir/-/common-dir-2.0.2.tgz",
+            "integrity": "sha512-AiVcdIuevkFWyqrcHhpOWJbaFBLm+OLPiaRy3QikrMypalgA4ehU1SugZO2rPawgdzkTAycXGs3F65PGPA2DWg==",
+            "dev": true,
+            "requires": {
+                "common-sequence": "^1.0.2"
+            }
+        },
+        "common-sequence": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-1.0.2.tgz",
+            "integrity": "sha1-MOB/P49vf5s97oVPILLTnu4Ibeg=",
+            "dev": true
+        },
+        "common-tags": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+            "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+            "dev": true
+        },
+        "commondir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+            "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+            "dev": true
+        },
+        "component-emitter": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+            "dev": true
+        },
+        "compressible": {
+            "version": "2.0.15",
+            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.15.tgz",
+            "integrity": "sha512-4aE67DL33dSW9gw4CI2H/yTxqHLNcxp0yS6jB+4h+wr3e43+1z7vm0HU9qXOH8j+qjKuL8+UtkOxYQSMq60Ylw==",
+            "dev": true,
+            "requires": {
+                "mime-db": ">= 1.36.0 < 2"
+            }
+        },
+        "compression": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
+            "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
+            "dev": true,
+            "requires": {
+                "accepts": "~1.3.5",
+                "bytes": "3.0.0",
+                "compressible": "~2.0.14",
+                "debug": "2.6.9",
+                "on-headers": "~1.0.1",
+                "safe-buffer": "5.1.2",
+                "vary": "~1.1.2"
+            }
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "concat-stream": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
+            }
+        },
+        "configstore": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+            "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+            "dev": true,
+            "requires": {
+                "dot-prop": "^4.1.0",
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^1.0.0",
+                "unique-string": "^1.0.0",
+                "write-file-atomic": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
+            }
+        },
+        "connect-history-api-fallback": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
+            "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=",
+            "dev": true
+        },
+        "console-browserify": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+            "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+            "dev": true,
+            "requires": {
+                "date-now": "^0.1.4"
+            }
+        },
+        "console-control-strings": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+            "dev": true
+        },
+        "constants-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+            "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+            "dev": true
+        },
+        "content-disposition": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+            "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+            "dev": true
+        },
+        "content-type": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+            "dev": true
+        },
+        "convert-source-map": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+            "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            }
+        },
+        "cookie": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+            "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+            "dev": true
+        },
+        "cookie-signature": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+            "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+            "dev": true
+        },
+        "copy-concurrently": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+            "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+            "dev": true,
+            "requires": {
+                "aproba": "^1.1.1",
+                "fs-write-stream-atomic": "^1.0.8",
+                "iferr": "^0.1.5",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.0"
+            }
+        },
+        "copy-descriptor": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+            "dev": true
+        },
+        "copy-webpack-plugin": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.6.0.tgz",
+            "integrity": "sha512-Y+SQCF+0NoWQryez2zXn5J5knmr9z/9qSQt7fbL78u83rxmigOy8X5+BFn8CFSuX+nKT8gpYwJX68ekqtQt6ZA==",
+            "dev": true,
+            "requires": {
+                "cacache": "^10.0.4",
+                "find-cache-dir": "^1.0.0",
+                "globby": "^7.1.1",
+                "is-glob": "^4.0.0",
+                "loader-utils": "^1.1.0",
+                "minimatch": "^3.0.4",
+                "p-limit": "^1.0.0",
+                "serialize-javascript": "^1.4.0"
+            }
+        },
+        "copyfiles": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-1.2.0.tgz",
+            "integrity": "sha1-qNo6xBqiIgrim9PFi2mEKU8sWTw=",
+            "dev": true,
+            "requires": {
+                "glob": "^7.0.5",
+                "ltcdr": "^2.2.1",
+                "minimatch": "^3.0.3",
+                "mkdirp": "^0.5.1",
+                "noms": "0.0.0",
+                "through2": "^2.0.1"
+            }
+        },
+        "core-js": {
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+            "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+            "dev": true
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
+        "create-ecdh": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+            "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.1.0",
+                "elliptic": "^6.0.0"
+            }
+        },
+        "create-error-class": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+            "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+            "dev": true,
+            "requires": {
+                "capture-stack-trace": "^1.0.0"
+            }
+        },
+        "create-hash": {
+            "version": "1.2.0",
+            "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+            "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+            "dev": true,
+            "requires": {
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "md5.js": "^1.3.4",
+                "ripemd160": "^2.0.1",
+                "sha.js": "^2.4.0"
+            }
+        },
+        "create-hmac": {
+            "version": "1.1.7",
+            "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+            "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+            "dev": true,
+            "requires": {
+                "cipher-base": "^1.0.3",
+                "create-hash": "^1.1.0",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
+            }
+        },
+        "cross-spawn": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+            "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+            "dev": true,
+            "requires": {
+                "lru-cache": "^4.0.1",
+                "which": "^1.2.9"
+            }
+        },
+        "crypto-browserify": {
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+            "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+            "dev": true,
+            "requires": {
+                "browserify-cipher": "^1.0.0",
+                "browserify-sign": "^4.0.0",
+                "create-ecdh": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.0",
+                "diffie-hellman": "^5.0.0",
+                "inherits": "^2.0.1",
+                "pbkdf2": "^3.0.3",
+                "public-encrypt": "^4.0.0",
+                "randombytes": "^2.0.0",
+                "randomfill": "^1.0.3"
+            }
+        },
+        "crypto-random-string": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+            "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+            "dev": true
+        },
+        "css-color-names": {
+            "version": "0.0.4",
+            "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+            "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
+            "dev": true
+        },
+        "css-initials": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/css-initials/-/css-initials-0.2.0.tgz",
+            "integrity": "sha512-t80yjg0pi4VAIc5itIqLh6M+ZlA+cB+gUXEQkDR09+ExTDwLMGfJ8YviBsGW+DklIrb2k9fwB75Io8ooWXDxxw==",
+            "dev": true
+        },
+        "css-loader": {
+            "version": "0.28.11",
+            "resolved": "http://registry.npmjs.org/css-loader/-/css-loader-0.28.11.tgz",
+            "integrity": "sha512-wovHgjAx8ZIMGSL8pTys7edA1ClmzxHeY6n/d97gg5odgsxEgKjULPR0viqyC+FWMCL9sfqoC/QCUBo62tLvPg==",
+            "dev": true,
+            "requires": {
+                "babel-code-frame": "^6.26.0",
+                "css-selector-tokenizer": "^0.7.0",
+                "cssnano": "^3.10.0",
+                "icss-utils": "^2.1.0",
+                "loader-utils": "^1.0.2",
+                "lodash.camelcase": "^4.3.0",
+                "object-assign": "^4.1.1",
+                "postcss": "^5.0.6",
+                "postcss-modules-extract-imports": "^1.2.0",
+                "postcss-modules-local-by-default": "^1.2.0",
+                "postcss-modules-scope": "^1.1.0",
+                "postcss-modules-values": "^1.3.0",
+                "postcss-value-parser": "^3.3.0",
+                "source-list-map": "^2.0.0"
+            }
+        },
+        "css-select": {
+            "version": "1.2.0",
+            "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+            "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+            "dev": true,
+            "requires": {
+                "boolbase": "~1.0.0",
+                "css-what": "2.1",
+                "domutils": "1.5.1",
+                "nth-check": "~1.0.1"
+            }
+        },
+        "css-selector-tokenizer": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
+            "integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
+            "dev": true,
+            "requires": {
+                "cssesc": "^0.1.0",
+                "fastparse": "^1.1.1",
+                "regexpu-core": "^1.0.0"
+            },
+            "dependencies": {
+                "regexpu-core": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+                    "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+                    "dev": true,
+                    "requires": {
+                        "regenerate": "^1.2.1",
+                        "regjsgen": "^0.2.0",
+                        "regjsparser": "^0.1.4"
+                    }
+                }
+            }
+        },
+        "css-what": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.2.tgz",
+            "integrity": "sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ==",
+            "dev": true
+        },
+        "cssesc": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+            "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+            "dev": true
+        },
+        "cssnano": {
+            "version": "3.10.0",
+            "resolved": "http://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+            "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
+            "dev": true,
+            "requires": {
+                "autoprefixer": "^6.3.1",
+                "decamelize": "^1.1.2",
+                "defined": "^1.0.0",
+                "has": "^1.0.1",
+                "object-assign": "^4.0.1",
+                "postcss": "^5.0.14",
+                "postcss-calc": "^5.2.0",
+                "postcss-colormin": "^2.1.8",
+                "postcss-convert-values": "^2.3.4",
+                "postcss-discard-comments": "^2.0.4",
+                "postcss-discard-duplicates": "^2.0.1",
+                "postcss-discard-empty": "^2.0.1",
+                "postcss-discard-overridden": "^0.1.1",
+                "postcss-discard-unused": "^2.2.1",
+                "postcss-filter-plugins": "^2.0.0",
+                "postcss-merge-idents": "^2.1.5",
+                "postcss-merge-longhand": "^2.0.1",
+                "postcss-merge-rules": "^2.0.3",
+                "postcss-minify-font-values": "^1.0.2",
+                "postcss-minify-gradients": "^1.0.1",
+                "postcss-minify-params": "^1.0.4",
+                "postcss-minify-selectors": "^2.0.4",
+                "postcss-normalize-charset": "^1.1.0",
+                "postcss-normalize-url": "^3.0.7",
+                "postcss-ordered-values": "^2.1.0",
+                "postcss-reduce-idents": "^2.2.2",
+                "postcss-reduce-initial": "^1.0.0",
+                "postcss-reduce-transforms": "^1.0.3",
+                "postcss-svgo": "^2.1.1",
+                "postcss-unique-selectors": "^2.0.2",
+                "postcss-value-parser": "^3.2.3",
+                "postcss-zindex": "^2.0.1"
+            }
+        },
+        "csso": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+            "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
+            "dev": true,
+            "requires": {
+                "clap": "^1.0.9",
+                "source-map": "^0.5.3"
+            }
+        },
+        "cssom": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
+            "integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
+            "dev": true
+        },
+        "cssstyle": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz",
+            "integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
+            "dev": true,
+            "requires": {
+                "cssom": "0.3.x"
+            }
+        },
+        "csstype": {
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.7.tgz",
+            "integrity": "sha512-Nt5VDyOTIIV4/nRFswoCKps1R5CD1hkiyjBE9/thNaNZILLEviVw9yWQw15+O+CpNjQKB/uvdcxFFOrSflY3Yw==",
+            "dev": true
+        },
+        "currently-unhandled": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+            "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+            "dev": true,
+            "requires": {
+                "array-find-index": "^1.0.1"
+            }
+        },
+        "cyclist": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+            "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+            "dev": true
+        },
+        "d": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
+            "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+            "dev": true,
+            "requires": {
+                "es5-ext": "^0.10.9"
+            }
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "data-urls": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+            "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+            "dev": true,
+            "requires": {
+                "abab": "^2.0.0",
+                "whatwg-mimetype": "^2.2.0",
+                "whatwg-url": "^7.0.0"
+            }
+        },
+        "date-now": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+            "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+            "dev": true
+        },
+        "debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "requires": {
+                "ms": "2.0.0"
+            }
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
+        },
+        "decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+            "dev": true
+        },
+        "deep-eql": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+            "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+            "dev": true,
+            "requires": {
+                "type-detect": "^4.0.0"
+            }
+        },
+        "deep-equal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+            "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+            "dev": true
+        },
+        "deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "dev": true
+        },
+        "deep-is": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "defaults": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+            "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+            "dev": true,
+            "requires": {
+                "clone": "^1.0.2"
+            }
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
+            "requires": {
+                "object-keys": "^1.0.12"
+            }
+        },
+        "define-property": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+            "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+            "dev": true,
+            "requires": {
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
+            },
+            "dependencies": {
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "defined": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+            "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+            "dev": true
+        },
+        "del": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+            "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+            "dev": true,
+            "requires": {
+                "globby": "^6.1.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "p-map": "^1.1.1",
+                "pify": "^3.0.0",
+                "rimraf": "^2.2.8"
+            },
+            "dependencies": {
+                "globby": {
+                    "version": "6.1.0",
+                    "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+                    "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+                    "dev": true,
+                    "requires": {
+                        "array-union": "^1.0.1",
+                        "glob": "^7.0.3",
+                        "object-assign": "^4.0.1",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "2.3.0",
+                            "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                            "dev": true
+                        }
+                    }
+                }
+            }
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
+        },
+        "delegates": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+            "dev": true
+        },
+        "depd": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+            "dev": true
+        },
+        "des.js": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+            "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
+            }
+        },
+        "destroy": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+            "dev": true
+        },
+        "detect-indent": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+            "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+            "dev": true,
+            "requires": {
+                "repeating": "^2.0.0"
+            }
+        },
+        "detect-node": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+            "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
+            "dev": true
+        },
+        "detect-port-alt": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
+            "integrity": "sha512-5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q==",
+            "dev": true,
+            "requires": {
+                "address": "^1.0.1",
+                "debug": "^2.6.0"
+            }
+        },
+        "diff": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+            "dev": true
+        },
+        "diffie-hellman": {
+            "version": "5.0.3",
+            "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+            "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.1.0",
+                "miller-rabin": "^4.0.0",
+                "randombytes": "^2.0.0"
+            }
+        },
+        "dir-glob": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+            "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+            "dev": true,
+            "requires": {
+                "arrify": "^1.0.1",
+                "path-type": "^3.0.0"
+            },
+            "dependencies": {
+                "path-type": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                    "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "discontinuous-range": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+            "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
+            "dev": true
+        },
+        "dns-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+            "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
+            "dev": true
+        },
+        "dns-packet": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
+            "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+            "dev": true,
+            "requires": {
+                "ip": "^1.1.0",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "dns-txt": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
+            "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+            "dev": true,
+            "requires": {
+                "buffer-indexof": "^1.0.0"
+            }
+        },
+        "doctrine": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+            "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+            "dev": true,
+            "requires": {
+                "esutils": "^2.0.2"
+            }
+        },
+        "dom-converter": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
+            "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
+            "dev": true,
+            "requires": {
+                "utila": "~0.4"
+            }
+        },
+        "dom-serializer": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+            "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+            "dev": true,
+            "requires": {
+                "domelementtype": "~1.1.1",
+                "entities": "~1.1.1"
+            },
+            "dependencies": {
+                "domelementtype": {
+                    "version": "1.1.3",
+                    "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                    "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+                    "dev": true
+                }
+            }
+        },
+        "dom-walk": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+            "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
+            "dev": true
+        },
+        "domain-browser": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+            "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+            "dev": true
+        },
+        "domelementtype": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.2.1.tgz",
+            "integrity": "sha512-SQVCLFS2E7G5CRCMdn6K9bIhRj1bS6QBWZfF0TUPh4V/BbqrQ619IdSS3/izn0FZ+9l+uODzaZjb08fjOfablA==",
+            "dev": true
+        },
+        "domexception": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+            "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+            "dev": true,
+            "requires": {
+                "webidl-conversions": "^4.0.2"
+            }
+        },
+        "domhandler": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+            "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+            "dev": true,
+            "requires": {
+                "domelementtype": "1"
+            }
+        },
+        "domutils": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+            "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+            "dev": true,
+            "requires": {
+                "dom-serializer": "0",
+                "domelementtype": "1"
+            }
+        },
+        "dot-prop": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+            "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+            "dev": true,
+            "requires": {
+                "is-obj": "^1.0.0"
+            }
+        },
+        "duplexer": {
+            "version": "0.1.1",
+            "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+            "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+            "dev": true
+        },
+        "duplexer3": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+            "dev": true
+        },
+        "duplexify": {
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
+            "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
+            }
+        },
+        "ecc-jsbn": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "dev": true,
+            "requires": {
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
+            }
+        },
+        "editions": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+            "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
+            "dev": true
+        },
+        "ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+            "dev": true
+        },
+        "electron-to-chromium": {
+            "version": "1.3.84",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.84.tgz",
+            "integrity": "sha512-IYhbzJYOopiTaNWMBp7RjbecUBsbnbDneOP86f3qvS0G0xfzwNSvMJpTrvi5/Y1gU7tg2NAgeg8a8rCYvW9Whw==",
+            "dev": true
+        },
+        "elliptic": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+            "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+            }
+        },
+        "emoji-regex": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
+            "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4=",
+            "dev": true
+        },
+        "emojis-list": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+            "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+            "dev": true
+        },
+        "encodeurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+            "dev": true
+        },
+        "end-of-stream": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+            "dev": true,
+            "requires": {
+                "once": "^1.4.0"
+            }
+        },
+        "enhanced-resolve": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.3.0.tgz",
+            "integrity": "sha512-2qbxE7ek3YxPJ1ML6V+satHkzHpJQKWkRHmRx6mfAoW59yP8YH8BFplbegSP+u2hBd6B6KCOpvJQ3dZAP+hkpg==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "memory-fs": "^0.4.0",
+                "object-assign": "^4.0.1",
+                "tapable": "^0.2.5"
+            }
+        },
+        "entities": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+            "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+            "dev": true
+        },
+        "enzyme": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.7.0.tgz",
+            "integrity": "sha512-QLWx+krGK6iDNyR1KlH5YPZqxZCQaVF6ike1eDJAOg0HvSkSCVImPsdWaNw6v+VrnK92Kg8jIOYhuOSS9sBpyg==",
+            "dev": true,
+            "requires": {
+                "array.prototype.flat": "^1.2.1",
+                "cheerio": "^1.0.0-rc.2",
+                "function.prototype.name": "^1.1.0",
+                "has": "^1.0.3",
+                "is-boolean-object": "^1.0.0",
+                "is-callable": "^1.1.4",
+                "is-number-object": "^1.0.3",
+                "is-string": "^1.0.4",
+                "is-subset": "^0.1.1",
+                "lodash.escape": "^4.0.1",
+                "lodash.isequal": "^4.5.0",
+                "object-inspect": "^1.6.0",
+                "object-is": "^1.0.1",
+                "object.assign": "^4.1.0",
+                "object.entries": "^1.0.4",
+                "object.values": "^1.0.4",
+                "raf": "^3.4.0",
+                "rst-selector-parser": "^2.2.3",
+                "string.prototype.trim": "^1.1.2"
+            }
+        },
+        "enzyme-adapter-react-16": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.7.0.tgz",
+            "integrity": "sha512-rDr0xlnnFPffAPYrvG97QYJaRl9unVDslKee33wTStsBEwZTkESX1H7VHGT5eUc6ifNzPgOJGvSh2zpHT4gXjA==",
+            "dev": true,
+            "requires": {
+                "enzyme-adapter-utils": "^1.9.0",
+                "function.prototype.name": "^1.1.0",
+                "object.assign": "^4.1.0",
+                "object.values": "^1.0.4",
+                "prop-types": "^15.6.2",
+                "react-is": "^16.6.1",
+                "react-test-renderer": "^16.0.0-0"
+            }
+        },
+        "enzyme-adapter-utils": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.9.0.tgz",
+            "integrity": "sha512-uMe4xw4l/Iloh2Fz+EO23XUYMEQXj5k/5ioLUXCNOUCI8Dml5XQMO9+QwUq962hBsY5qftfHHns+d990byWHvg==",
+            "dev": true,
+            "requires": {
+                "function.prototype.name": "^1.1.0",
+                "object.assign": "^4.1.0",
+                "prop-types": "^15.6.2",
+                "semver": "^5.6.0"
+            }
+        },
+        "errno": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+            "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+            "dev": true,
+            "requires": {
+                "prr": "~1.0.1"
+            }
+        },
+        "error-ex": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dev": true,
+            "requires": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
+        "es-abstract": {
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+            "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+            "dev": true,
+            "requires": {
+                "es-to-primitive": "^1.1.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.1",
+                "is-callable": "^1.1.3",
+                "is-regex": "^1.0.4"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+            "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+            "dev": true,
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
+        "es5-ext": {
+            "version": "0.10.46",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
+            "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
+            "dev": true,
+            "requires": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.1",
+                "next-tick": "1"
+            }
+        },
+        "es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
+            }
+        },
+        "es6-map": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+            "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "~0.10.14",
+                "es6-iterator": "~2.0.1",
+                "es6-set": "~0.1.5",
+                "es6-symbol": "~3.1.1",
+                "event-emitter": "~0.3.5"
+            }
+        },
+        "es6-object-assign": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+            "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
+            "dev": true
+        },
+        "es6-promise": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+            "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
+            "dev": true
+        },
+        "es6-set": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+            "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "~0.10.14",
+                "es6-iterator": "~2.0.1",
+                "es6-symbol": "3.1.1",
+                "event-emitter": "~0.3.5"
+            }
+        },
+        "es6-symbol": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+            "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "~0.10.14"
+            }
+        },
+        "es6-weak-map": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+            "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.14",
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
+            }
+        },
+        "escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+            "dev": true
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "escodegen": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
+            "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+            "dev": true,
+            "requires": {
+                "esprima": "^3.1.3",
+                "estraverse": "^4.2.0",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1",
+                "source-map": "~0.6.1"
+            },
+            "dependencies": {
+                "esprima": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+                    "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "escope": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+            "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+            "dev": true,
+            "requires": {
+                "es6-map": "^0.1.3",
+                "es6-weak-map": "^2.0.1",
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
+            }
+        },
+        "eslint": {
+            "version": "2.13.1",
+            "resolved": "http://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+            "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.1.3",
+                "concat-stream": "^1.4.6",
+                "debug": "^2.1.1",
+                "doctrine": "^1.2.2",
+                "es6-map": "^0.1.3",
+                "escope": "^3.6.0",
+                "espree": "^3.1.6",
+                "estraverse": "^4.2.0",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^1.1.1",
+                "glob": "^7.0.3",
+                "globals": "^9.2.0",
+                "ignore": "^3.1.2",
+                "imurmurhash": "^0.1.4",
+                "inquirer": "^0.12.0",
+                "is-my-json-valid": "^2.10.0",
+                "is-resolvable": "^1.0.0",
+                "js-yaml": "^3.5.1",
+                "json-stable-stringify": "^1.0.0",
+                "levn": "^0.3.0",
+                "lodash": "^4.0.0",
+                "mkdirp": "^0.5.0",
+                "optionator": "^0.8.1",
+                "path-is-absolute": "^1.0.0",
+                "path-is-inside": "^1.0.1",
+                "pluralize": "^1.2.1",
+                "progress": "^1.1.8",
+                "require-uncached": "^1.0.2",
+                "shelljs": "^0.6.0",
+                "strip-json-comments": "~1.0.1",
+                "table": "^3.7.8",
+                "text-table": "~0.2.0",
+                "user-home": "^2.0.0"
+            },
+            "dependencies": {
+                "ansi-escapes": {
+                    "version": "1.4.0",
+                    "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+                    "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "cli-cursor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+                    "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+                    "dev": true,
+                    "requires": {
+                        "restore-cursor": "^1.0.1"
+                    }
+                },
+                "doctrine": {
+                    "version": "1.5.0",
+                    "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+                    "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "isarray": "^1.0.0"
+                    }
+                },
+                "figures": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+                    "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+                    "dev": true,
+                    "requires": {
+                        "escape-string-regexp": "^1.0.5",
+                        "object-assign": "^4.1.0"
+                    }
+                },
+                "inquirer": {
+                    "version": "0.12.0",
+                    "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+                    "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-escapes": "^1.1.0",
+                        "ansi-regex": "^2.0.0",
+                        "chalk": "^1.0.0",
+                        "cli-cursor": "^1.0.1",
+                        "cli-width": "^2.0.0",
+                        "figures": "^1.3.5",
+                        "lodash": "^4.3.0",
+                        "readline2": "^1.0.1",
+                        "run-async": "^0.1.0",
+                        "rx-lite": "^3.1.2",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.0",
+                        "through": "^2.3.6"
+                    }
+                },
+                "onetime": {
+                    "version": "1.1.0",
+                    "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+                    "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+                    "dev": true
+                },
+                "restore-cursor": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+                    "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+                    "dev": true,
+                    "requires": {
+                        "exit-hook": "^1.0.0",
+                        "onetime": "^1.0.0"
+                    }
+                },
+                "run-async": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+                    "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+                    "dev": true,
+                    "requires": {
+                        "once": "^1.3.0"
+                    }
+                },
+                "rx-lite": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+                    "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+                    "dev": true
+                },
+                "strip-json-comments": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+                    "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "espree": {
+            "version": "3.5.4",
+            "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+            "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+            "dev": true,
+            "requires": {
+                "acorn": "^5.5.0",
+                "acorn-jsx": "^3.0.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.7.3",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+                    "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+                    "dev": true
+                },
+                "acorn-jsx": {
+                    "version": "3.0.1",
+                    "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+                    "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+                    "dev": true,
+                    "requires": {
+                        "acorn": "^3.0.4"
+                    },
+                    "dependencies": {
+                        "acorn": {
+                            "version": "3.3.0",
+                            "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+                            "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+                            "dev": true
+                        }
+                    }
+                }
+            }
+        },
+        "esprima": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+            "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+            "dev": true
+        },
+        "esrecurse": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+            "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+            "dev": true,
+            "requires": {
+                "estraverse": "^4.1.0"
+            }
+        },
+        "estraverse": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
+        },
+        "etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+            "dev": true
+        },
+        "event-emitter": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+            "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "~0.10.14"
+            }
+        },
+        "event-stream": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
+            "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
+            "dev": true,
+            "requires": {
+                "duplexer": "^0.1.1",
+                "flatmap-stream": "^0.1.0",
+                "from": "^0.1.7",
+                "map-stream": "0.0.7",
+                "pause-stream": "^0.0.11",
+                "split": "^1.0.1",
+                "stream-combiner": "^0.2.2",
+                "through": "^2.3.8"
+            }
+        },
+        "eventemitter3": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+            "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
+            "dev": true
+        },
+        "events": {
+            "version": "1.1.1",
+            "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+            "dev": true
+        },
+        "eventsource": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
+            "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
+            "dev": true,
+            "requires": {
+                "original": ">=0.0.5"
+            }
+        },
+        "evp_bytestokey": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+            "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+            "dev": true,
+            "requires": {
+                "md5.js": "^1.3.4",
+                "safe-buffer": "^5.1.1"
+            }
+        },
+        "execa": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+            "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                    "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                }
+            }
+        },
+        "exit-hook": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+            "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+            "dev": true
+        },
+        "expand-brackets": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+            "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+            "dev": true,
+            "requires": {
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "expand-range": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+            "dev": true,
+            "requires": {
+                "fill-range": "^2.1.0"
+            },
+            "dependencies": {
+                "fill-range": {
+                    "version": "2.2.4",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+                    "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^2.1.0",
+                        "isobject": "^2.0.0",
+                        "randomatic": "^3.0.0",
+                        "repeat-element": "^1.1.2",
+                        "repeat-string": "^1.5.2"
+                    }
+                },
+                "is-number": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+                    "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    }
+                },
+                "isobject": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                    "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                    "dev": true,
+                    "requires": {
+                        "isarray": "1.0.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "expand-tilde": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+            "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+            "dev": true,
+            "requires": {
+                "homedir-polyfill": "^1.0.1"
+            }
+        },
+        "express": {
+            "version": "4.16.4",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
+            "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+            "dev": true,
+            "requires": {
+                "accepts": "~1.3.5",
+                "array-flatten": "1.1.1",
+                "body-parser": "1.18.3",
+                "content-disposition": "0.5.2",
+                "content-type": "~1.0.4",
+                "cookie": "0.3.1",
+                "cookie-signature": "1.0.6",
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "finalhandler": "1.1.1",
+                "fresh": "0.5.2",
+                "merge-descriptors": "1.0.1",
+                "methods": "~1.1.2",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.2",
+                "path-to-regexp": "0.1.7",
+                "proxy-addr": "~2.0.4",
+                "qs": "6.5.2",
+                "range-parser": "~1.2.0",
+                "safe-buffer": "5.1.2",
+                "send": "0.16.2",
+                "serve-static": "1.13.2",
+                "setprototypeof": "1.1.0",
+                "statuses": "~1.4.0",
+                "type-is": "~1.6.16",
+                "utils-merge": "1.0.1",
+                "vary": "~1.1.2"
+            },
+            "dependencies": {
+                "array-flatten": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+                    "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+                    "dev": true
+                }
+            }
+        },
+        "extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "dev": true
+        },
+        "extend-shallow": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+            "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+            "dev": true,
+            "requires": {
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                }
+            }
+        },
+        "external-editor": {
+            "version": "2.2.0",
+            "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+            "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+            "dev": true,
+            "requires": {
+                "chardet": "^0.4.0",
+                "iconv-lite": "^0.4.17",
+                "tmp": "^0.0.33"
+            }
+        },
+        "extglob": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+            "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+            "dev": true,
+            "requires": {
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "dev": true
+        },
+        "fast-deep-equal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+            "dev": true
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+            "dev": true
+        },
+        "fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
+        "fastparse": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
+            "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
+            "dev": true
+        },
+        "faye-websocket": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+            "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+            "dev": true,
+            "requires": {
+                "websocket-driver": ">=0.5.1"
+            }
+        },
+        "figures": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+            "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "^1.0.5"
+            }
+        },
+        "file-entry-cache": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+            "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
+            "dev": true,
+            "requires": {
+                "flat-cache": "^1.2.1",
+                "object-assign": "^4.0.1"
+            }
+        },
+        "filename-regex": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+            "dev": true
+        },
+        "filesize": {
+            "version": "3.5.11",
+            "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.5.11.tgz",
+            "integrity": "sha512-ZH7loueKBoDb7yG9esn1U+fgq7BzlzW6NRi5/rMdxIZ05dj7GFD/Xc5rq2CDt5Yq86CyfSYVyx4242QQNZbx1g==",
+            "dev": true
+        },
+        "fill-range": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+            "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "finalhandler": {
+            "version": "1.1.1",
+            "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+            "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.2",
+                "statuses": "~1.4.0",
+                "unpipe": "~1.0.0"
+            }
+        },
+        "find-cache-dir": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+            "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+            "dev": true,
+            "requires": {
+                "commondir": "^1.0.1",
+                "make-dir": "^1.0.0",
+                "pkg-dir": "^2.0.0"
+            }
+        },
+        "find-up": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+            "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+            "dev": true,
+            "requires": {
+                "locate-path": "^2.0.0"
+            }
+        },
+        "findup": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
+            "integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
+            "dev": true,
+            "requires": {
+                "colors": "~0.6.0-1",
+                "commander": "~2.1.0"
+            },
+            "dependencies": {
+                "colors": {
+                    "version": "0.6.2",
+                    "resolved": "http://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+                    "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+                    "dev": true
+                },
+                "commander": {
+                    "version": "2.1.0",
+                    "resolved": "http://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+                    "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
+                    "dev": true
+                }
+            }
+        },
+        "flat-cache": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+            "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+            "dev": true,
+            "requires": {
+                "circular-json": "^0.3.1",
+                "graceful-fs": "^4.1.2",
+                "rimraf": "~2.6.2",
+                "write": "^0.2.1"
+            }
+        },
+        "flatmap-stream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.2.tgz",
+            "integrity": "sha512-ucyr6WkLXjyMuHPtOUq4l+nSAxgWi7v4QO508eQ9resnGj+lSup26oIsUI5aH8k4Qfpjsxa8dDf9UCKkS2KHzQ==",
+            "dev": true
+        },
+        "flatten": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+            "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
+            "dev": true
+        },
+        "flush-write-stream": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+            "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.4"
+            }
+        },
+        "follow-redirects": {
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+            "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+            "dev": true,
+            "requires": {
+                "debug": "=3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+            "dev": true
+        },
+        "for-own": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "dev": true,
+            "requires": {
+                "for-in": "^1.0.1"
+            }
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
+        },
+        "form-data": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "dev": true,
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+            }
+        },
+        "forwarded": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+            "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+            "dev": true
+        },
+        "fragment-cache": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+            "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+            "dev": true,
+            "requires": {
+                "map-cache": "^0.2.2"
+            }
+        },
+        "fresh": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+            "dev": true
+        },
+        "from": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+            "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+            "dev": true
+        },
+        "from2": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+            "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0"
+            }
+        },
+        "front-matter": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-2.1.2.tgz",
+            "integrity": "sha1-91mDufL0E75ljJPf172M5AePXNs=",
+            "dev": true,
+            "requires": {
+                "js-yaml": "^3.4.6"
+            }
+        },
+        "fs-extra": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+            "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^3.0.0",
+                "universalify": "^0.1.0"
+            }
+        },
+        "fs-write-stream-atomic": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+            "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "iferr": "^0.1.5",
+                "imurmurhash": "^0.1.4",
+                "readable-stream": "1 || 2"
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "fsevents": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+            "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "nan": "^2.9.2",
+                "node-pre-gyp": "^0.10.0"
+            },
+            "dependencies": {
+                "abbrev": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "aproba": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
+                    }
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "chownr": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "deep-extend": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "detect-libc": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "fs-minipass": {
+                    "version": "1.2.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "minipass": "^2.2.1"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "iconv-lite": {
+                    "version": "0.4.21",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "safer-buffer": "^2.1.0"
+                    }
+                },
+                "ignore-walk": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "minimatch": "^3.0.4"
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "once": "^1.3.0",
+                        "wrappy": "1"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ini": {
+                    "version": "1.3.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "bundled": true,
+                    "dev": true
+                },
+                "minipass": {
+                    "version": "2.2.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.0"
+                    }
+                },
+                "minizlib": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "minipass": "^2.2.1"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "needle": {
+                    "version": "2.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "debug": "^2.1.2",
+                        "iconv-lite": "^0.4.4",
+                        "sax": "^1.2.4"
+                    }
+                },
+                "node-pre-gyp": {
+                    "version": "0.10.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "detect-libc": "^1.0.2",
+                        "mkdirp": "^0.5.1",
+                        "needle": "^2.2.0",
+                        "nopt": "^4.0.1",
+                        "npm-packlist": "^1.1.6",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.1.7",
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^4"
+                    }
+                },
+                "nopt": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
+                    }
+                },
+                "npm-bundled": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "npm-packlist": {
+                    "version": "1.1.10",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1"
+                    }
+                },
+                "npmlog": {
+                    "version": "4.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "osenv": {
+                    "version": "0.1.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "rc": {
+                    "version": "1.2.7",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "deep-extend": "^0.5.1",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "glob": "^7.0.5"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "safer-buffer": {
+                    "version": "2.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "sax": {
+                    "version": "1.2.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "semver": {
+                    "version": "5.5.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "tar": {
+                    "version": "4.4.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "chownr": "^1.0.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.2.4",
+                        "minizlib": "^1.1.0",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.2"
+                    }
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "wide-align": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "string-width": "^1.0.2"
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true
+                }
+            }
+        },
+        "fstream": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+            "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
+            }
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
+        "function.name-polyfill": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/function.name-polyfill/-/function.name-polyfill-1.0.6.tgz",
+            "integrity": "sha512-ejQivNFbBPTY5O/waFta6D5AzV8GJiM/fMDaT6LrsYax1cb4eipxuQqKNlugF2jlcXIjifsqvju3wsgV35TELg==",
+            "dev": true
+        },
+        "function.prototype.name": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
+            "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "is-callable": "^1.1.3"
+            }
+        },
+        "gauge": {
+            "version": "2.7.4",
+            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+            "dev": true,
+            "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+            }
+        },
+        "gaze": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+            "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
+            "dev": true,
+            "requires": {
+                "globule": "^1.0.0"
+            }
+        },
+        "generate-function": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+            "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+            "dev": true,
+            "requires": {
+                "is-property": "^1.0.2"
+            }
+        },
+        "generate-object-property": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+            "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+            "dev": true,
+            "requires": {
+                "is-property": "^1.0.0"
+            }
+        },
+        "get-caller-file": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+            "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+            "dev": true
+        },
+        "get-func-name": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+            "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+            "dev": true
+        },
+        "get-own-enumerable-property-symbols": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
+            "integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg==",
+            "dev": true
+        },
+        "get-stdin": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+            "dev": true
+        },
+        "get-stream": {
+            "version": "3.0.0",
+            "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+            "dev": true
+        },
+        "get-value": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+            "dev": true
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "github-slugger": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.2.0.tgz",
+            "integrity": "sha512-wIaa75k1vZhyPm9yWrD08A5Xnx/V+RmzGrpjQuLemGKSb77Qukiaei58Bogrl/LZSADDfPzKJX8jhLs4CRTl7Q==",
+            "dev": true,
+            "requires": {
+                "emoji-regex": ">=6.0.0 <=6.1.1"
+            }
+        },
+        "glob": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+            "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "glob-base": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+            "dev": true,
+            "requires": {
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
+            },
+            "dependencies": {
+                "glob-parent": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^2.0.0"
+                    }
+                },
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "glob-parent": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+            "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+            "dev": true,
+            "requires": {
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
+            },
+            "dependencies": {
+                "is-glob": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.0"
+                    }
+                }
+            }
+        },
+        "global": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+            "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+            "dev": true,
+            "requires": {
+                "min-document": "^2.19.0",
+                "process": "~0.5.1"
+            }
+        },
+        "global-dirs": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+            "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+            "dev": true,
+            "requires": {
+                "ini": "^1.3.4"
+            }
+        },
+        "global-modules": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+            "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+            "dev": true,
+            "requires": {
+                "global-prefix": "^1.0.1",
+                "is-windows": "^1.0.1",
+                "resolve-dir": "^1.0.0"
+            }
+        },
+        "global-prefix": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+            "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+            "dev": true,
+            "requires": {
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
+            }
+        },
+        "globals": {
+            "version": "9.18.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+            "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+            "dev": true
+        },
+        "globby": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+            "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+            "dev": true,
+            "requires": {
+                "array-union": "^1.0.1",
+                "dir-glob": "^2.0.0",
+                "glob": "^7.1.2",
+                "ignore": "^3.3.5",
+                "pify": "^3.0.0",
+                "slash": "^1.0.0"
+            }
+        },
+        "globule": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
+            "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+            "dev": true,
+            "requires": {
+                "glob": "~7.1.1",
+                "lodash": "~4.17.10",
+                "minimatch": "~3.0.2"
+            }
+        },
+        "glogg": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+            "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
+            "dev": true,
+            "requires": {
+                "sparkles": "^1.0.0"
+            }
+        },
+        "gonzales-pe-sl": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/gonzales-pe-sl/-/gonzales-pe-sl-4.2.3.tgz",
+            "integrity": "sha1-aoaLw4BkXxQf7rBCxvl/zHG1n+Y=",
+            "dev": true,
+            "requires": {
+                "minimist": "1.1.x"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.1.3",
+                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+                    "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
+                    "dev": true
+                }
+            }
+        },
+        "got": {
+            "version": "6.7.1",
+            "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+            "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+            "dev": true,
+            "requires": {
+                "create-error-class": "^3.0.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-redirect": "^1.0.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "lowercase-keys": "^1.0.0",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "unzip-response": "^2.0.1",
+                "url-parse-lax": "^1.0.0"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.1.15",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+            "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+            "dev": true
+        },
+        "growl": {
+            "version": "1.10.5",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+            "dev": true
+        },
+        "gzip-size": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
+            "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
+            "dev": true,
+            "requires": {
+                "duplexer": "^0.1.1"
+            }
+        },
+        "handle-thing": {
+            "version": "1.2.5",
+            "resolved": "http://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+            "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
+            "dev": true
+        },
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true
+        },
+        "har-validator": {
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.5.5",
+                "har-schema": "^2.0.0"
+            }
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            }
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "has-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+            "dev": true
+        },
+        "has-unicode": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+            "dev": true
+        },
+        "has-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+            "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+            "dev": true,
+            "requires": {
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
+            }
+        },
+        "has-values": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+            "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+            "dev": true,
+            "requires": {
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "hash-base": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+            "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "hash.js": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
+            "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.1"
+            }
+        },
+        "he": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "dev": true
+        },
+        "highlight.js": {
+            "version": "9.13.1",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
+            "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
+            "dev": true
+        },
+        "hmac-drbg": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+            "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+            "dev": true,
+            "requires": {
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
+            }
+        },
+        "hoist-non-react-statics": {
+            "version": "2.5.5",
+            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+            "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
+            "dev": true
+        },
+        "home-or-tmp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+            "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+            "dev": true,
+            "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.1"
+            }
+        },
+        "homedir-polyfill": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+            "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+            "dev": true,
+            "requires": {
+                "parse-passwd": "^1.0.0"
+            }
+        },
+        "hosted-git-info": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+            "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+            "dev": true
+        },
+        "hpack.js": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+            "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "obuf": "^1.0.0",
+                "readable-stream": "^2.0.1",
+                "wbuf": "^1.1.0"
+            }
+        },
+        "html": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/html/-/html-1.0.0.tgz",
+            "integrity": "sha1-pUT6nqVJK/s6LMqCEKEL57WvH2E=",
+            "dev": true,
+            "requires": {
+                "concat-stream": "^1.4.7"
+            }
+        },
+        "html-comment-regex": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
+            "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==",
+            "dev": true
+        },
+        "html-encoding-sniffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+            "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+            "dev": true,
+            "requires": {
+                "whatwg-encoding": "^1.0.1"
+            }
+        },
+        "html-entities": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+            "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
+            "dev": true
+        },
+        "html-minifier": {
+            "version": "3.5.21",
+            "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
+            "integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
+            "dev": true,
+            "requires": {
+                "camel-case": "3.0.x",
+                "clean-css": "4.2.x",
+                "commander": "2.17.x",
+                "he": "1.2.x",
+                "param-case": "2.1.x",
+                "relateurl": "0.2.x",
+                "uglify-js": "3.4.x"
+            }
+        },
+        "html-webpack-plugin": {
+            "version": "2.30.1",
+            "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.30.1.tgz",
+            "integrity": "sha1-f5xCG36pHsRg9WUn1430hO51N9U=",
+            "dev": true,
+            "requires": {
+                "bluebird": "^3.4.7",
+                "html-minifier": "^3.2.3",
+                "loader-utils": "^0.2.16",
+                "lodash": "^4.17.3",
+                "pretty-error": "^2.0.2",
+                "toposort": "^1.0.0"
+            },
+            "dependencies": {
+                "loader-utils": {
+                    "version": "0.2.17",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+                    "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+                    "dev": true,
+                    "requires": {
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0",
+                        "object-assign": "^4.0.1"
+                    }
+                }
+            }
+        },
+        "htmlparser2": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
+            "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
+            "dev": true,
+            "requires": {
+                "domelementtype": "^1.3.0",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^3.0.6"
+            },
+            "dependencies": {
+                "domelementtype": {
+                    "version": "1.3.0",
+                    "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+                    "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "3.0.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
+                    "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "http-deceiver": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+            "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
+            "dev": true
+        },
+        "http-errors": {
+            "version": "1.6.3",
+            "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+            "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+            "dev": true,
+            "requires": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.1.0",
+                "statuses": ">= 1.4.0 < 2"
+            }
+        },
+        "http-parser-js": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.0.tgz",
+            "integrity": "sha512-cZdEF7r4gfRIq7ezX9J0T+kQmJNOub71dWbgAXVHDct80TKP4MCETtZQ31xyv38UwgzkWPYF/Xc0ge55dW9Z9w==",
+            "dev": true
+        },
+        "http-proxy": {
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
+            "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+            "dev": true,
+            "requires": {
+                "eventemitter3": "^3.0.0",
+                "follow-redirects": "^1.0.0",
+                "requires-port": "^1.0.0"
+            }
+        },
+        "http-proxy-middleware": {
+            "version": "0.17.4",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+            "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
+            "dev": true,
+            "requires": {
+                "http-proxy": "^1.16.2",
+                "is-glob": "^3.1.0",
+                "lodash": "^4.17.2",
+                "micromatch": "^2.3.11"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "^1.0.1"
+                    }
+                },
+                "array-unique": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "1.8.5",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+                    "dev": true,
+                    "requires": {
+                        "expand-range": "^1.8.1",
+                        "preserve": "^0.2.0",
+                        "repeat-element": "^1.1.2"
+                    }
+                },
+                "expand-brackets": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+                    "dev": true,
+                    "requires": {
+                        "is-posix-bracket": "^0.1.0"
+                    }
+                },
+                "extglob": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "is-extglob": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                            "dev": true
+                        }
+                    }
+                },
+                "is-glob": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                },
+                "micromatch": {
+                    "version": "2.3.11",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^2.0.0",
+                        "array-unique": "^0.2.1",
+                        "braces": "^1.8.2",
+                        "expand-brackets": "^0.1.4",
+                        "extglob": "^0.3.1",
+                        "filename-regex": "^2.0.0",
+                        "is-extglob": "^1.0.0",
+                        "is-glob": "^2.0.1",
+                        "kind-of": "^3.0.2",
+                        "normalize-path": "^2.0.1",
+                        "object.omit": "^2.0.0",
+                        "parse-glob": "^3.0.4",
+                        "regex-cache": "^0.4.2"
+                    },
+                    "dependencies": {
+                        "is-extglob": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                            "dev": true
+                        },
+                        "is-glob": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                            "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                            "dev": true,
+                            "requires": {
+                                "is-extglob": "^1.0.0"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "http-signature": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+            }
+        },
+        "https-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+            "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+            "dev": true
+        },
+        "hyphenate-style-name": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
+            "integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es=",
+            "dev": true
+        },
+        "iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            }
+        },
+        "icss-replace-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+            "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+            "dev": true
+        },
+        "icss-utils": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
+            "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
+            "dev": true,
+            "requires": {
+                "postcss": "^6.0.1"
+            },
+            "dependencies": {
+                "postcss": {
+                    "version": "6.0.23",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "ieee754": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+            "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
+            "dev": true
+        },
+        "iferr": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+            "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+            "dev": true
+        },
+        "ignore": {
+            "version": "3.3.10",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+            "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+            "dev": true
+        },
+        "ignore-by-default": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+            "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
+            "dev": true
+        },
+        "ignore-styles": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ignore-styles/-/ignore-styles-5.0.1.tgz",
+            "integrity": "sha1-tJ7yJ0va/NikiAqWa/440aC/RnE=",
+            "dev": true
+        },
+        "import-lazy": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+            "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+            "dev": true
+        },
+        "import-local": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+            "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+            "dev": true,
+            "requires": {
+                "pkg-dir": "^2.0.0",
+                "resolve-cwd": "^2.0.0"
+            }
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
+        },
+        "in-publish": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+            "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
+            "dev": true
+        },
+        "indent-string": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+            "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+            "dev": true,
+            "requires": {
+                "repeating": "^2.0.0"
+            }
+        },
+        "indexes-of": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+            "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+            "dev": true
+        },
+        "indexof": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+            "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "ini": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+            "dev": true
+        },
+        "inquirer": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+            "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^2.0.4",
+                "figures": "^2.0.0",
+                "lodash": "^4.3.0",
+                "mute-stream": "0.0.7",
+                "run-async": "^2.2.0",
+                "rx-lite": "^4.0.8",
+                "rx-lite-aggregates": "^4.0.8",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
+                "through": "^2.3.6"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "internal-ip": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
+            "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
+            "dev": true,
+            "requires": {
+                "meow": "^3.3.0"
+            }
+        },
+        "interpret": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+            "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+            "dev": true
+        },
+        "invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.0.0"
+            }
+        },
+        "invert-kv": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "dev": true
+        },
+        "ip": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+            "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+            "dev": true
+        },
+        "ipaddr.js": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+            "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
+            "dev": true
+        },
+        "is-absolute-url": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+            "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
+            "dev": true
+        },
+        "is-accessor-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "is-alphabetical": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.2.tgz",
+            "integrity": "sha512-V0xN4BYezDHcBSKb1QHUFMlR4as/XEuCZBzMJUU4n7+Cbt33SmUnSol+pnXFvLxSHNq2CemUXNdaXV6Flg7+xg==",
+            "dev": true
+        },
+        "is-alphanumeric": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
+            "integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ=",
+            "dev": true
+        },
+        "is-alphanumerical": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
+            "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
+            "dev": true,
+            "requires": {
+                "is-alphabetical": "^1.0.0",
+                "is-decimal": "^1.0.0"
+            }
+        },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
+        },
+        "is-binary-path": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+            "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+            "dev": true,
+            "requires": {
+                "binary-extensions": "^1.0.0"
+            }
+        },
+        "is-boolean-object": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
+            "integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=",
+            "dev": true
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+            "dev": true
+        },
+        "is-builtin-module": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+            "dev": true,
+            "requires": {
+                "builtin-modules": "^1.0.0"
+            }
+        },
+        "is-callable": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+            "dev": true
+        },
+        "is-ci": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+            "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+            "dev": true,
+            "requires": {
+                "ci-info": "^1.5.0"
+            }
+        },
+        "is-data-descriptor": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "is-date-object": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+            "dev": true
+        },
+        "is-decimal": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.2.tgz",
+            "integrity": "sha512-TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg==",
+            "dev": true
+        },
+        "is-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+            "dev": true,
+            "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
+        },
+        "is-directory": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+            "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+            "dev": true
+        },
+        "is-dotfile": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+            "dev": true
+        },
+        "is-equal-shallow": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+            "dev": true,
+            "requires": {
+                "is-primitive": "^2.0.0"
+            }
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+            "dev": true
+        },
+        "is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true
+        },
+        "is-finite": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+            "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+            "dev": true,
+            "requires": {
+                "number-is-nan": "^1.0.0"
+            }
+        },
+        "is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "dev": true,
+            "requires": {
+                "number-is-nan": "^1.0.0"
+            }
+        },
+        "is-glob": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+            "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+            "dev": true,
+            "requires": {
+                "is-extglob": "^2.1.1"
+            }
+        },
+        "is-hexadecimal": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
+            "integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A==",
+            "dev": true
+        },
+        "is-in-browser": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+            "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU=",
+            "dev": true
+        },
+        "is-installed-globally": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+            "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+            "dev": true,
+            "requires": {
+                "global-dirs": "^0.1.0",
+                "is-path-inside": "^1.0.0"
+            }
+        },
+        "is-my-ip-valid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+            "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+            "dev": true
+        },
+        "is-my-json-valid": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
+            "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
+            "dev": true,
+            "requires": {
+                "generate-function": "^2.0.0",
+                "generate-object-property": "^1.1.0",
+                "is-my-ip-valid": "^1.0.0",
+                "jsonpointer": "^4.0.0",
+                "xtend": "^4.0.0"
+            }
+        },
+        "is-npm": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+            "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+            "dev": true
+        },
+        "is-number": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+            "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "is-number-object": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
+            "integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
+            "dev": true
+        },
+        "is-obj": {
+            "version": "1.0.1",
+            "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+            "dev": true
+        },
+        "is-path-cwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+            "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+            "dev": true
+        },
+        "is-path-in-cwd": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+            "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+            "dev": true,
+            "requires": {
+                "is-path-inside": "^1.0.0"
+            }
+        },
+        "is-path-inside": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+            "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+            "dev": true,
+            "requires": {
+                "path-is-inside": "^1.0.1"
+            }
+        },
+        "is-plain-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+            "dev": true
+        },
+        "is-plain-object": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "dev": true,
+            "requires": {
+                "isobject": "^3.0.1"
+            }
+        },
+        "is-posix-bracket": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+            "dev": true
+        },
+        "is-primitive": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+            "dev": true
+        },
+        "is-promise": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+            "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+            "dev": true
+        },
+        "is-property": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+            "dev": true
+        },
+        "is-redirect": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+            "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+            "dev": true
+        },
+        "is-regex": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+            "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.1"
+            }
+        },
+        "is-regexp": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+            "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+            "dev": true
+        },
+        "is-resolvable": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+            "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+            "dev": true
+        },
+        "is-retry-allowed": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+            "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+            "dev": true
+        },
+        "is-root": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz",
+            "integrity": "sha1-B7bCM7w5TNnQK6FclmvWZg1jQtU=",
+            "dev": true
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
+        },
+        "is-string": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
+            "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
+            "dev": true
+        },
+        "is-subset": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+            "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+            "dev": true
+        },
+        "is-svg": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+            "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
+            "dev": true,
+            "requires": {
+                "html-comment-regex": "^1.1.0"
+            }
+        },
+        "is-symbol": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+            "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.0"
+            }
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
+        "is-utf8": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+            "dev": true
+        },
+        "is-whitespace-character": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz",
+            "integrity": "sha512-SzM+T5GKUCtLhlHFKt2SDAX2RFzfS6joT91F2/WSi9LxgFdsnhfPK/UIA+JhRR2xuyLdrCys2PiFDrtn1fU5hQ==",
+            "dev": true
+        },
+        "is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+            "dev": true
+        },
+        "is-word-character": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.2.tgz",
+            "integrity": "sha512-T3FlsX8rCHAH8e7RE7PfOPZVFQlcV3XRF9eOOBQ1uf70OxO7CjjSOjeImMPCADBdYWcStAbVbYvJ1m2D3tb+EA==",
+            "dev": true
+        },
+        "is-wsl": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+            "dev": true
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "isobject": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+            "dev": true
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
+        },
+        "istanbul-lib-coverage": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+            "integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA==",
+            "dev": true
+        },
+        "istanbul-lib-instrument": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.0.0.tgz",
+            "integrity": "sha512-eQY9vN9elYjdgN9Iv6NS/00bptm02EBBk70lRMaVjeA6QYocQgenVrSgC28TJurdnZa80AGO3ASdFN+w/njGiQ==",
+            "dev": true,
+            "requires": {
+                "@babel/generator": "^7.0.0",
+                "@babel/parser": "^7.0.0",
+                "@babel/template": "^7.0.0",
+                "@babel/traverse": "^7.0.0",
+                "@babel/types": "^7.0.0",
+                "istanbul-lib-coverage": "^2.0.1",
+                "semver": "^5.5.0"
+            }
+        },
+        "javascript-stringify": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/javascript-stringify/-/javascript-stringify-1.6.0.tgz",
+            "integrity": "sha1-FC0RHzpuPa6PSpr9d9RYVbWpzOM=",
+            "dev": true
+        },
+        "js-base64": {
+            "version": "2.4.9",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.9.tgz",
+            "integrity": "sha512-xcinL3AuDJk7VSzsHgb9DvvIXayBbadtMZ4HFPx8rUszbW1MuNMlwYVC4zzCZ6e1sqZpnNS5ZFYOhXqA39T7LQ==",
+            "dev": true
+        },
+        "js-tokens": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+            "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^2.6.0"
+            }
+        },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true
+        },
+        "jsdom": {
+            "version": "12.2.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-12.2.0.tgz",
+            "integrity": "sha512-QPOggIJ8fquWPLaYYMoh+zqUmdphDtu1ju0QGTitZT1Yd8I5qenPpXM1etzUegu3MjVp8XPzgZxdn8Yj7e40ig==",
+            "dev": true,
+            "requires": {
+                "abab": "^2.0.0",
+                "acorn": "^6.0.2",
+                "acorn-globals": "^4.3.0",
+                "array-equal": "^1.0.0",
+                "cssom": "^0.3.4",
+                "cssstyle": "^1.1.1",
+                "data-urls": "^1.0.1",
+                "domexception": "^1.0.1",
+                "escodegen": "^1.11.0",
+                "html-encoding-sniffer": "^1.0.2",
+                "nwsapi": "^2.0.9",
+                "parse5": "5.1.0",
+                "pn": "^1.1.0",
+                "request": "^2.88.0",
+                "request-promise-native": "^1.0.5",
+                "saxes": "^3.1.3",
+                "symbol-tree": "^3.2.2",
+                "tough-cookie": "^2.4.3",
+                "w3c-hr-time": "^1.0.1",
+                "webidl-conversions": "^4.0.2",
+                "whatwg-encoding": "^1.0.5",
+                "whatwg-mimetype": "^2.2.0",
+                "whatwg-url": "^7.0.0",
+                "ws": "^6.1.0",
+                "xml-name-validator": "^3.0.0"
+            },
+            "dependencies": {
+                "parse5": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+                    "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+                    "dev": true
+                }
+            }
+        },
+        "jsesc": {
+            "version": "1.3.0",
+            "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+            "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+            "dev": true
+        },
+        "json-loader": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
+            "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
+            "dev": true
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true
+        },
+        "json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
+        "json-stable-stringify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+            "dev": true,
+            "requires": {
+                "jsonify": "~0.0.0"
+            }
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true
+        },
+        "json3": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+            "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+            "dev": true
+        },
+        "json5": {
+            "version": "0.5.1",
+            "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+            "dev": true
+        },
+        "jsonfile": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+            "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "jsonify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
+        },
+        "jsonpointer": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+            "dev": true
+        },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
+        },
+        "jss": {
+            "version": "9.8.7",
+            "resolved": "https://registry.npmjs.org/jss/-/jss-9.8.7.tgz",
+            "integrity": "sha512-awj3XRZYxbrmmrx9LUSj5pXSUfm12m8xzi/VKeqI1ZwWBtQ0kVPTs3vYs32t4rFw83CgFDukA8wKzOE9sMQnoQ==",
+            "dev": true,
+            "requires": {
+                "is-in-browser": "^1.1.3",
+                "symbol-observable": "^1.1.0",
+                "warning": "^3.0.0"
+            }
+        },
+        "jss-camel-case": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jss-camel-case/-/jss-camel-case-6.1.0.tgz",
+            "integrity": "sha512-HPF2Q7wmNW1t79mCqSeU2vdd/vFFGpkazwvfHMOhPlMgXrJDzdj9viA2SaHk9ZbD5pfL63a8ylp4++irYbbzMQ==",
+            "dev": true,
+            "requires": {
+                "hyphenate-style-name": "^1.0.2"
+            }
+        },
+        "jss-compose": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/jss-compose/-/jss-compose-5.0.0.tgz",
+            "integrity": "sha512-YofRYuiA0+VbeOw0VjgkyO380sA4+TWDrW52nSluD9n+1FWOlDzNbgpZ/Sb3Y46+DcAbOS21W5jo6SAqUEiuwA==",
+            "dev": true,
+            "requires": {
+                "warning": "^3.0.0"
+            }
+        },
+        "jss-default-unit": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
+            "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg==",
+            "dev": true
+        },
+        "jss-global": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
+            "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q==",
+            "dev": true
+        },
+        "jss-isolate": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/jss-isolate/-/jss-isolate-5.1.0.tgz",
+            "integrity": "sha512-8OVa/SObXRMaKvFeCqzpDOZY8So4fAcTH0K6LsITiYpEQNABICSx1NCmubnt/JbPQaqnnQsF5F47uG86uQ9ZRA==",
+            "dev": true,
+            "requires": {
+                "css-initials": "^0.2.0"
+            }
+        },
+        "jss-nested": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/jss-nested/-/jss-nested-6.0.1.tgz",
+            "integrity": "sha512-rn964TralHOZxoyEgeq3hXY8hyuCElnvQoVrQwKHVmu55VRDd6IqExAx9be5HgK0yN/+hQdgAXQl/GUrBbbSTA==",
+            "dev": true,
+            "requires": {
+                "warning": "^3.0.0"
+            }
+        },
+        "just-extend": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
+            "integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ==",
+            "dev": true
+        },
+        "killable": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
+            "integrity": "sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==",
+            "dev": true
+        },
+        "kind-of": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+            "dev": true
+        },
+        "kleur": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-2.0.2.tgz",
+            "integrity": "sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ==",
+            "dev": true
+        },
+        "known-css-properties": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.3.0.tgz",
+            "integrity": "sha512-QMQcnKAiQccfQTqtBh/qwquGZ2XK/DXND1jrcN9M8gMMy99Gwla7GQjndVUsEqIaRyP6bsFRuhwRj5poafBGJQ==",
+            "dev": true
+        },
+        "latest-version": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+            "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+            "dev": true,
+            "requires": {
+                "package-json": "^4.0.0"
+            }
+        },
+        "lazy-cache": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+            "dev": true
+        },
+        "lcid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "dev": true,
+            "requires": {
+                "invert-kv": "^1.0.0"
+            }
+        },
+        "leven": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+            "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+            "dev": true
+        },
+        "levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
+            }
+        },
+        "listify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/listify/-/listify-1.0.0.tgz",
+            "integrity": "sha1-A8p7otFQ1CZ3c/dOV1WNEFPSvuM=",
+            "dev": true
+        },
+        "load-json-file": {
+            "version": "1.1.0",
+            "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+            "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                }
+            }
+        },
+        "loader-runner": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.1.tgz",
+            "integrity": "sha512-By6ZFY7ETWOc9RFaAIb23IjJVcM4dvJC/N57nmdz9RSkMXvAXGI7SyVlAw3v8vjtDRlqThgVDVmTnr9fqMlxkw==",
+            "dev": true
+        },
+        "loader-utils": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+            "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+            "dev": true,
+            "requires": {
+                "big.js": "^3.1.3",
+                "emojis-list": "^2.0.0",
+                "json5": "^0.5.0"
+            }
+        },
+        "locate-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "dev": true,
+            "requires": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+            }
+        },
+        "lodash": {
+            "version": "4.17.11",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+            "dev": true
+        },
+        "lodash.assign": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+            "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+            "dev": true
+        },
+        "lodash.camelcase": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+            "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+            "dev": true
+        },
+        "lodash.capitalize": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+            "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk=",
+            "dev": true
+        },
+        "lodash.clonedeep": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+            "dev": true
+        },
+        "lodash.debounce": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+            "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+            "dev": true
+        },
+        "lodash.escape": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+            "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
+            "dev": true
+        },
+        "lodash.flattendeep": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+            "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+            "dev": true
+        },
+        "lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+            "dev": true
+        },
+        "lodash.isequal": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+            "dev": true
+        },
+        "lodash.kebabcase": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+            "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
+            "dev": true
+        },
+        "lodash.memoize": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+            "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+            "dev": true
+        },
+        "lodash.mergewith": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
+            "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
+            "dev": true
+        },
+        "lodash.sortby": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+            "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+            "dev": true
+        },
+        "lodash.tail": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
+            "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
+            "dev": true
+        },
+        "lodash.uniq": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+            "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+            "dev": true
+        },
+        "log-symbols": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+            "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.1"
+            }
+        },
+        "loglevel": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
+            "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=",
+            "dev": true
+        },
+        "lolex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.0.0.tgz",
+            "integrity": "sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==",
+            "dev": true
+        },
+        "longest": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+            "dev": true
+        },
+        "longest-streak": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.2.tgz",
+            "integrity": "sha512-TmYTeEYxiAmSVdpbnQDXGtvYOIRsCMg89CVZzwzc2o7GFL1CjoiRPjH5ec0NFAVlAx3fVof9dX/t6KKRAo2OWA==",
+            "dev": true
+        },
+        "loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
+            "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            }
+        },
+        "loud-rejection": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+            "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+            "dev": true,
+            "requires": {
+                "currently-unhandled": "^0.4.1",
+                "signal-exit": "^3.0.0"
+            }
+        },
+        "lower-case": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+            "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+            "dev": true
+        },
+        "lowercase-keys": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+            "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+            "dev": true
+        },
+        "lru-cache": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+            "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+            "dev": true,
+            "requires": {
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
+            }
+        },
+        "ltcdr": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ltcdr/-/ltcdr-2.2.1.tgz",
+            "integrity": "sha1-Wrh60dTB2rjowIu/A37gwZAih88=",
+            "dev": true
+        },
+        "magic-string": {
+            "version": "0.22.5",
+            "resolved": "http://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+            "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+            "dev": true,
+            "requires": {
+                "vlq": "^0.2.2"
+            },
+            "dependencies": {
+                "vlq": {
+                    "version": "0.2.3",
+                    "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+                    "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+                    "dev": true
+                }
+            }
+        },
+        "make-dir": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+            "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+            "dev": true,
+            "requires": {
+                "pify": "^3.0.0"
+            }
+        },
+        "make-error": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+            "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+            "dev": true
+        },
+        "map-cache": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+            "dev": true
+        },
+        "map-obj": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+            "dev": true
+        },
+        "map-stream": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+            "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
+            "dev": true
+        },
+        "map-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+            "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+            "dev": true,
+            "requires": {
+                "object-visit": "^1.0.0"
+            }
+        },
+        "markdown-escapes": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.2.tgz",
+            "integrity": "sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA==",
+            "dev": true
+        },
+        "markdown-table": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.2.tgz",
+            "integrity": "sha512-NcWuJFHDA8V3wkDgR/j4+gZx+YQwstPgfQDV8ndUeWWzta3dnDTBxpVzqS9lkmJAuV5YX35lmyojl6HO5JXAgw==",
+            "dev": true
+        },
+        "markdown-to-jsx": {
+            "version": "6.8.4",
+            "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.8.4.tgz",
+            "integrity": "sha512-zBp1u2gR8tZGfdCPvD4WRYtO/zAzMDqMwvb1GKjRfPd+eOZVcmkovlpOnNjyV/eufyjhUiZJ4Xw5gvjHwiTzCg==",
+            "dev": true,
+            "requires": {
+                "prop-types": "^15.6.2",
+                "unquote": "^1.1.0"
+            }
+        },
+        "math-expression-evaluator": {
+            "version": "1.2.17",
+            "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
+            "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
+            "dev": true
+        },
+        "math-random": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+            "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+            "dev": true
+        },
+        "md5.js": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+            "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+            "dev": true,
+            "requires": {
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            }
+        },
+        "mdast-util-compact": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.2.tgz",
+            "integrity": "sha512-d2WS98JSDVbpSsBfVvD9TaDMlqPRz7ohM/11G0rp5jOBb5q96RJ6YLszQ/09AAixyzh23FeIpCGqfaamEADtWg==",
+            "dev": true,
+            "requires": {
+                "unist-util-visit": "^1.1.0"
+            }
+        },
+        "media-typer": {
+            "version": "0.3.0",
+            "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+            "dev": true
+        },
+        "mem": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+            "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+            "dev": true,
+            "requires": {
+                "mimic-fn": "^1.0.0"
+            }
+        },
+        "memory-fs": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+            "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+            "dev": true,
+            "requires": {
+                "errno": "^0.1.3",
+                "readable-stream": "^2.0.1"
+            }
+        },
+        "meow": {
+            "version": "3.7.0",
+            "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+            "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+            "dev": true,
+            "requires": {
+                "camelcase-keys": "^2.0.0",
+                "decamelize": "^1.1.2",
+                "loud-rejection": "^1.0.0",
+                "map-obj": "^1.0.1",
+                "minimist": "^1.1.3",
+                "normalize-package-data": "^2.3.4",
+                "object-assign": "^4.0.1",
+                "read-pkg-up": "^1.0.1",
+                "redent": "^1.0.0",
+                "trim-newlines": "^1.0.0"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
+            }
+        },
+        "merge": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+            "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+            "dev": true
+        },
+        "merge-descriptors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+            "dev": true
+        },
+        "methods": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+            "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+            "dev": true
+        },
+        "micromatch": {
+            "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+            "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+            "dev": true,
+            "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+            }
+        },
+        "miller-rabin": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+            "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.0.0",
+                "brorand": "^1.0.1"
+            }
+        },
+        "mime": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+            "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+            "dev": true
+        },
+        "mime-db": {
+            "version": "1.37.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+            "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+            "dev": true
+        },
+        "mime-types": {
+            "version": "2.1.21",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+            "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+            "dev": true,
+            "requires": {
+                "mime-db": "~1.37.0"
+            }
+        },
+        "mimic-fn": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+            "dev": true
+        },
+        "min-document": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+            "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+            "dev": true,
+            "requires": {
+                "dom-walk": "^0.1.0"
+            }
+        },
+        "mini-html-webpack-plugin": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/mini-html-webpack-plugin/-/mini-html-webpack-plugin-0.2.3.tgz",
+            "integrity": "sha512-wfkLf+CmyDg++K1S0QdAvUvS29DfVHe9SQ63syX8aX375mInzC5uwHxb/1+3exiiv84xnPrf6zsOnReRe15rjg==",
+            "dev": true,
+            "requires": {
+                "webpack-sources": "^1.1.0"
+            }
+        },
+        "minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+            "dev": true
+        },
+        "minimalistic-crypto-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+            "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "dev": true
+        },
+        "mississippi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
+            "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+            "dev": true,
+            "requires": {
+                "concat-stream": "^1.5.0",
+                "duplexify": "^3.4.2",
+                "end-of-stream": "^1.1.0",
+                "flush-write-stream": "^1.0.0",
+                "from2": "^2.1.0",
+                "parallel-transform": "^1.1.0",
+                "pump": "^2.0.1",
+                "pumpify": "^1.3.3",
+                "stream-each": "^1.1.0",
+                "through2": "^2.0.0"
+            }
+        },
+        "mixin-deep": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+            "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+            "dev": true,
+            "requires": {
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                }
+            }
+        },
+        "mixin-object": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+            "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+            "dev": true,
+            "requires": {
+                "for-in": "^0.1.3",
+                "is-extendable": "^0.1.1"
+            },
+            "dependencies": {
+                "for-in": {
+                    "version": "0.1.8",
+                    "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+                    "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
+                    "dev": true
+                }
+            }
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.8"
+            }
+        },
+        "mocha": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+            "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+            "dev": true,
+            "requires": {
+                "browser-stdout": "1.3.1",
+                "commander": "2.15.1",
+                "debug": "3.1.0",
+                "diff": "3.5.0",
+                "escape-string-regexp": "1.0.5",
+                "glob": "7.1.2",
+                "growl": "1.10.5",
+                "he": "1.1.1",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "supports-color": "5.4.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.15.1",
+                    "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+                    "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "he": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+                    "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "moo": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
+            "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
+            "dev": true
+        },
+        "move-concurrently": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+            "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+            "dev": true,
+            "requires": {
+                "aproba": "^1.1.1",
+                "copy-concurrently": "^1.0.0",
+                "fs-write-stream-atomic": "^1.0.8",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.3"
+            }
+        },
+        "ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "multicast-dns": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
+            "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+            "dev": true,
+            "requires": {
+                "dns-packet": "^1.3.1",
+                "thunky": "^1.0.2"
+            }
+        },
+        "multicast-dns-service-types": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+            "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
+            "dev": true
+        },
+        "mute-stream": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+            "dev": true
+        },
+        "nan": {
+            "version": "2.11.1",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+            "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+            "dev": true
+        },
+        "nanomatch": {
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+            "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+            "dev": true,
+            "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            }
+        },
+        "nearley": {
+            "version": "2.15.1",
+            "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.15.1.tgz",
+            "integrity": "sha512-8IUY/rUrKz2mIynUGh8k+tul1awMKEjeHHC5G3FHvvyAW6oq4mQfNp2c0BMea+sYZJvYcrrM6GmZVIle/GRXGw==",
+            "dev": true,
+            "requires": {
+                "moo": "^0.4.3",
+                "nomnom": "~1.6.2",
+                "railroad-diagrams": "^1.0.0",
+                "randexp": "0.4.6",
+                "semver": "^5.4.1"
+            }
+        },
+        "negotiator": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+            "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+            "dev": true
+        },
+        "neo-async": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+            "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+            "dev": true
+        },
+        "next-tick": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+            "dev": true
+        },
+        "nise": {
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.6.tgz",
+            "integrity": "sha512-1GedetLKzmqmgwabuMSqPsT7oumdR77SBpDfNNJhADRIeA3LN/2RVqR4fFqwvzhAqcTef6PPCzQwITE/YQ8S8A==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/formatio": "3.0.0",
+                "just-extend": "^3.0.0",
+                "lolex": "^2.3.2",
+                "path-to-regexp": "^1.7.0",
+                "text-encoding": "^0.6.4"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "lolex": {
+                    "version": "2.7.5",
+                    "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+                    "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+                    "dev": true
+                },
+                "path-to-regexp": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+                    "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+                    "dev": true,
+                    "requires": {
+                        "isarray": "0.0.1"
+                    }
+                }
+            }
+        },
+        "no-case": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+            "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+            "dev": true,
+            "requires": {
+                "lower-case": "^1.1.1"
+            }
+        },
+        "node-dir": {
+            "version": "0.1.17",
+            "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
+            "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
+            "dev": true,
+            "requires": {
+                "minimatch": "^3.0.2"
+            }
+        },
+        "node-forge": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+            "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==",
+            "dev": true
+        },
+        "node-gyp": {
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
+            "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+            "dev": true,
+            "requires": {
+                "fstream": "^1.0.0",
+                "glob": "^7.0.3",
+                "graceful-fs": "^4.1.2",
+                "mkdirp": "^0.5.0",
+                "nopt": "2 || 3",
+                "npmlog": "0 || 1 || 2 || 3 || 4",
+                "osenv": "0",
+                "request": "^2.87.0",
+                "rimraf": "2",
+                "semver": "~5.3.0",
+                "tar": "^2.0.0",
+                "which": "1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.3.0",
+                    "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+                    "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+                    "dev": true
+                }
+            }
+        },
+        "node-libs-browser": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
+            "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
+            "dev": true,
+            "requires": {
+                "assert": "^1.1.1",
+                "browserify-zlib": "^0.2.0",
+                "buffer": "^4.3.0",
+                "console-browserify": "^1.1.0",
+                "constants-browserify": "^1.0.0",
+                "crypto-browserify": "^3.11.0",
+                "domain-browser": "^1.1.1",
+                "events": "^1.0.0",
+                "https-browserify": "^1.0.0",
+                "os-browserify": "^0.3.0",
+                "path-browserify": "0.0.0",
+                "process": "^0.11.10",
+                "punycode": "^1.2.4",
+                "querystring-es3": "^0.2.0",
+                "readable-stream": "^2.3.3",
+                "stream-browserify": "^2.0.1",
+                "stream-http": "^2.7.2",
+                "string_decoder": "^1.0.0",
+                "timers-browserify": "^2.0.4",
+                "tty-browserify": "0.0.0",
+                "url": "^0.11.0",
+                "util": "^0.10.3",
+                "vm-browserify": "0.0.4"
+            },
+            "dependencies": {
+                "process": {
+                    "version": "0.11.10",
+                    "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+                    "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+                    "dev": true
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                    "dev": true
+                }
+            }
+        },
+        "node-sass": {
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.10.0.tgz",
+            "integrity": "sha512-fDQJfXszw6vek63Fe/ldkYXmRYK/QS6NbvM3i5oEo9ntPDy4XX7BcKZyTKv+/kSSxRtXXc7l+MSwEmYc0CSy6Q==",
+            "dev": true,
+            "requires": {
+                "async-foreach": "^0.1.3",
+                "chalk": "^1.1.1",
+                "cross-spawn": "^3.0.0",
+                "gaze": "^1.0.0",
+                "get-stdin": "^4.0.1",
+                "glob": "^7.0.3",
+                "in-publish": "^2.0.0",
+                "lodash.assign": "^4.2.0",
+                "lodash.clonedeep": "^4.3.2",
+                "lodash.mergewith": "^4.6.0",
+                "meow": "^3.7.0",
+                "mkdirp": "^0.5.1",
+                "nan": "^2.10.0",
+                "node-gyp": "^3.8.0",
+                "npmlog": "^4.0.0",
+                "request": "^2.88.0",
+                "sass-graph": "^2.2.4",
+                "stdout-stream": "^1.4.0",
+                "true-case-path": "^1.0.2"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "nodemon": {
+            "version": "1.18.6",
+            "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.6.tgz",
+            "integrity": "sha512-4pHQNYEZun+IkIC2jCaXEhkZnfA7rQe73i8RkdRyDJls/K+WxR7IpI5uNUsAvQ0zWvYcCDNGD+XVtw2ZG86/uQ==",
+            "dev": true,
+            "requires": {
+                "chokidar": "^2.0.4",
+                "debug": "^3.1.0",
+                "ignore-by-default": "^1.0.1",
+                "minimatch": "^3.0.4",
+                "pstree.remy": "^1.1.0",
+                "semver": "^5.5.0",
+                "supports-color": "^5.2.0",
+                "touch": "^3.1.0",
+                "undefsafe": "^2.0.2",
+                "update-notifier": "^2.3.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "nomnom": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
+            "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
+            "dev": true,
+            "requires": {
+                "colors": "0.5.x",
+                "underscore": "~1.4.4"
+            },
+            "dependencies": {
+                "colors": {
+                    "version": "0.5.1",
+                    "resolved": "http://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+                    "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
+                    "dev": true
+                }
+            }
+        },
+        "noms": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+            "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "readable-stream": "~1.0.31"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "1.0.34",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "~0.10.x"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                }
+            }
+        },
+        "nopt": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+            "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+            "dev": true,
+            "requires": {
+                "abbrev": "1"
+            }
+        },
+        "normalize-package-data": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+            "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+            "dev": true,
+            "requires": {
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
+        "normalize-path": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+            "dev": true,
+            "requires": {
+                "remove-trailing-separator": "^1.0.1"
+            }
+        },
+        "normalize-range": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+            "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+            "dev": true
+        },
+        "normalize-url": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+            "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+            "dev": true,
+            "requires": {
+                "object-assign": "^4.0.1",
+                "prepend-http": "^1.0.0",
+                "query-string": "^4.1.0",
+                "sort-keys": "^1.0.0"
+            }
+        },
+        "npm-run-path": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "dev": true,
+            "requires": {
+                "path-key": "^2.0.0"
+            }
+        },
+        "npmlog": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+            "dev": true,
+            "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+            }
+        },
+        "nth-check": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+            "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+            "dev": true,
+            "requires": {
+                "boolbase": "~1.0.0"
+            }
+        },
+        "num2fraction": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+            "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+            "dev": true
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
+        },
+        "nwsapi": {
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz",
+            "integrity": "sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ==",
+            "dev": true
+        },
+        "nyc": {
+            "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.1.0.tgz",
+            "integrity": "sha512-3GyY6TpQ58z9Frpv4GMExE1SV2tAgYqC7HSy2omEhNiCT3mhT9NyiOvIE8zkbuJVFzmvvNTnE4h/7/wQae7xLg==",
+            "dev": true,
+            "requires": {
+                "archy": "^1.0.0",
+                "arrify": "^1.0.1",
+                "caching-transform": "^2.0.0",
+                "convert-source-map": "^1.6.0",
+                "debug-log": "^1.0.1",
+                "find-cache-dir": "^2.0.0",
+                "find-up": "^3.0.0",
+                "foreground-child": "^1.5.6",
+                "glob": "^7.1.3",
+                "istanbul-lib-coverage": "^2.0.1",
+                "istanbul-lib-hook": "^2.0.1",
+                "istanbul-lib-instrument": "^3.0.0",
+                "istanbul-lib-report": "^2.0.2",
+                "istanbul-lib-source-maps": "^2.0.1",
+                "istanbul-reports": "^2.0.1",
+                "make-dir": "^1.3.0",
+                "merge-source-map": "^1.1.0",
+                "resolve-from": "^4.0.0",
+                "rimraf": "^2.6.2",
+                "signal-exit": "^3.0.2",
+                "spawn-wrap": "^1.4.2",
+                "test-exclude": "^5.0.0",
+                "uuid": "^3.3.2",
+                "yargs": "11.1.0",
+                "yargs-parser": "^9.0.2"
+            },
+            "dependencies": {
+                "align-text": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2",
+                        "longest": "^1.0.1",
+                        "repeat-string": "^1.5.2"
+                    }
+                },
+                "amdefine": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "append-transform": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "default-require-extensions": "^2.0.0"
+                    }
+                },
+                "archy": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "arrify": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "async": {
+                    "version": "1.5.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "builtin-modules": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "caching-transform": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "make-dir": "^1.0.0",
+                        "md5-hex": "^2.0.0",
+                        "package-hash": "^2.0.0",
+                        "write-file-atomic": "^2.0.0"
+                    }
+                },
+                "camelcase": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "center-align": {
+                    "version": "0.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "align-text": "^0.1.3",
+                        "lazy-cache": "^1.0.3"
+                    }
+                },
+                "cliui": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "center-align": "^0.1.1",
+                        "right-align": "^0.1.1",
+                        "wordwrap": "0.0.2"
+                    },
+                    "dependencies": {
+                        "wordwrap": {
+                            "version": "0.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "commondir": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "convert-source-map": {
+                    "version": "1.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.1"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "4.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^4.0.1",
+                        "which": "^1.2.9"
+                    }
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "debug-log": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "decamelize": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "default-require-extensions": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "strip-bom": "^3.0.0"
+                    }
+                },
+                "error-ex": {
+                    "version": "1.3.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-arrayish": "^0.2.1"
+                    }
+                },
+                "es6-error": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "execa": {
+                    "version": "0.7.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "cross-spawn": {
+                            "version": "5.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "lru-cache": "^4.0.1",
+                                "shebang-command": "^1.2.0",
+                                "which": "^1.2.9"
+                            }
+                        }
+                    }
+                },
+                "find-cache-dir": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "commondir": "^1.0.1",
+                        "make-dir": "^1.0.0",
+                        "pkg-dir": "^3.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "foreground-child": {
+                    "version": "1.5.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^4",
+                        "signal-exit": "^3.0.0"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "get-caller-file": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "get-stream": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "glob": {
+                    "version": "7.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "bundled": true,
+                    "dev": true
+                },
+                "handlebars": {
+                    "version": "4.0.11",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "async": "^1.4.0",
+                        "optimist": "^0.6.1",
+                        "source-map": "^0.4.4",
+                        "uglify-js": "^2.6"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.4.4",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "amdefine": ">=0.0.4"
+                            }
+                        }
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "hosted-git-info": {
+                    "version": "2.7.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "imurmurhash": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "once": "^1.3.0",
+                        "wrappy": "1"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "invert-kv": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-arrayish": {
+                    "version": "0.2.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-buffer": {
+                    "version": "1.1.6",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-builtin-module": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "builtin-modules": "^1.0.0"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-stream": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "isexe": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "istanbul-lib-coverage": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "istanbul-lib-hook": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "append-transform": "^1.0.0"
+                    }
+                },
+                "istanbul-lib-report": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "istanbul-lib-coverage": "^2.0.1",
+                        "make-dir": "^1.3.0",
+                        "supports-color": "^5.4.0"
+                    }
+                },
+                "istanbul-lib-source-maps": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "debug": "^3.1.0",
+                        "istanbul-lib-coverage": "^2.0.1",
+                        "make-dir": "^1.3.0",
+                        "rimraf": "^2.6.2",
+                        "source-map": "^0.6.1"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.6.1",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "istanbul-reports": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "handlebars": "^4.0.11"
+                    }
+                },
+                "json-parse-better-errors": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                },
+                "lazy-cache": {
+                    "version": "1.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "lcid": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^1.0.0"
+                    }
+                },
+                "load-json-file": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^4.0.0",
+                        "pify": "^3.0.0",
+                        "strip-bom": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "lodash.flattendeep": {
+                    "version": "4.4.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "longest": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lru-cache": {
+                    "version": "4.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
+                    }
+                },
+                "make-dir": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "pify": "^3.0.0"
+                    }
+                },
+                "md5-hex": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "md5-o-matic": "^0.1.1"
+                    }
+                },
+                "md5-o-matic": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mem": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "mimic-fn": "^1.0.0"
+                    }
+                },
+                "merge-source-map": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "source-map": "^0.6.1"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.6.1",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "mimic-fn": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.10",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "0.0.8",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "normalize-package-data": {
+                    "version": "2.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "hosted-git-info": "^2.1.4",
+                        "is-builtin-module": "^1.0.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1"
+                    }
+                },
+                "npm-run-path": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                },
+                "optimist": {
+                    "version": "0.6.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimist": "~0.0.1",
+                        "wordwrap": "~0.0.2"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "os-locale": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "execa": "^0.7.0",
+                        "lcid": "^1.0.0",
+                        "mem": "^1.1.0"
+                    }
+                },
+                "p-finally": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "p-limit": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "package-hash": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "lodash.flattendeep": "^4.4.0",
+                        "md5-hex": "^2.0.0",
+                        "release-zalgo": "^1.0.0"
+                    }
+                },
+                "parse-json": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
+                    }
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-key": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-type": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "pify": "^3.0.0"
+                    }
+                },
+                "pify": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "pkg-dir": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^3.0.0"
+                    }
+                },
+                "pseudomap": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "^4.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^3.0.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^3.0.0",
+                        "read-pkg": "^3.0.0"
+                    }
+                },
+                "release-zalgo": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "es6-error": "^4.0.1"
+                    }
+                },
+                "repeat-string": {
+                    "version": "1.6.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "require-directory": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "require-main-filename": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "right-align": {
+                    "version": "0.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "align-text": "^0.1.1"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.0.5"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.5.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "shebang-command": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^1.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "spawn-wrap": {
+                    "version": "1.4.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "foreground-child": "^1.5.6",
+                        "mkdirp": "^0.5.0",
+                        "os-homedir": "^1.0.1",
+                        "rimraf": "^2.6.2",
+                        "signal-exit": "^3.0.2",
+                        "which": "^1.3.0"
+                    }
+                },
+                "spdx-correct": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "spdx-expression-parse": "^3.0.0",
+                        "spdx-license-ids": "^3.0.0"
+                    }
+                },
+                "spdx-exceptions": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "spdx-expression-parse": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "spdx-exceptions": "^2.1.0",
+                        "spdx-license-ids": "^3.0.0"
+                    }
+                },
+                "spdx-license-ids": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                },
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "strip-eof": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "test-exclude": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "arrify": "^1.0.1",
+                        "minimatch": "^3.0.4",
+                        "read-pkg-up": "^4.0.0",
+                        "require-main-filename": "^1.0.1"
+                    }
+                },
+                "uglify-js": {
+                    "version": "2.8.29",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "source-map": "~0.5.1",
+                        "uglify-to-browserify": "~1.0.0",
+                        "yargs": "~3.10.0"
+                    },
+                    "dependencies": {
+                        "yargs": {
+                            "version": "3.10.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "camelcase": "^1.0.2",
+                                "cliui": "^2.1.0",
+                                "decamelize": "^1.0.0",
+                                "window-size": "0.1.0"
+                            }
+                        }
+                    }
+                },
+                "uglify-to-browserify": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "uuid": {
+                    "version": "3.3.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "validate-npm-package-license": {
+                    "version": "3.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "spdx-correct": "^3.0.0",
+                        "spdx-expression-parse": "^3.0.0"
+                    }
+                },
+                "which": {
+                    "version": "1.3.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "window-size": {
+                    "version": "0.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "wordwrap": {
+                    "version": "0.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "wrap-ansi": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "2.1.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "number-is-nan": "^1.0.0"
+                            }
+                        },
+                        "string-width": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^2.0.0"
+                            }
+                        }
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "write-file-atomic": {
+                    "version": "2.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "imurmurhash": "^0.1.4",
+                        "signal-exit": "^3.0.2"
+                    }
+                },
+                "y18n": {
+                    "version": "3.2.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "2.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "11.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.1.1",
+                        "find-up": "^2.1.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^2.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^9.0.2"
+                    },
+                    "dependencies": {
+                        "cliui": {
+                            "version": "4.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "string-width": "^2.1.1",
+                                "strip-ansi": "^4.0.0",
+                                "wrap-ansi": "^2.0.0"
+                            }
+                        },
+                        "find-up": {
+                            "version": "2.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "locate-path": "^2.0.0"
+                            }
+                        },
+                        "locate-path": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "p-locate": "^2.0.0",
+                                "path-exists": "^3.0.0"
+                            }
+                        },
+                        "p-limit": {
+                            "version": "1.3.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "p-try": "^1.0.0"
+                            }
+                        },
+                        "p-locate": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "p-limit": "^1.1.0"
+                            }
+                        },
+                        "p-try": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "yargs-parser": {
+                    "version": "9.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^4.1.0"
+                    },
+                    "dependencies": {
+                        "camelcase": {
+                            "version": "4.1.0",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                }
+            }
+        },
+        "oauth-sign": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+            "dev": true
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "object-copy": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+            "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+            "dev": true,
+            "requires": {
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "object-inspect": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+            "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+            "dev": true
+        },
+        "object-is": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
+            "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
+            "dev": true
+        },
+        "object-keys": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+            "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+            "dev": true
+        },
+        "object-visit": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+            "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+            "dev": true,
+            "requires": {
+                "isobject": "^3.0.0"
+            }
+        },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
+            }
+        },
+        "object.entries": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
+            "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.6.1",
+                "function-bind": "^1.1.0",
+                "has": "^1.0.1"
+            }
+        },
+        "object.omit": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+            "dev": true,
+            "requires": {
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
+            }
+        },
+        "object.pick": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+            "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+            "dev": true,
+            "requires": {
+                "isobject": "^3.0.1"
+            }
+        },
+        "object.values": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
+            "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.6.1",
+                "function-bind": "^1.1.0",
+                "has": "^1.0.1"
+            }
+        },
+        "obuf": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+            "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+            "dev": true
+        },
+        "on-finished": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+            "dev": true,
+            "requires": {
+                "ee-first": "1.1.1"
+            }
+        },
+        "on-headers": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+            "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
+            "dev": true
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "onetime": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+            "dev": true,
+            "requires": {
+                "mimic-fn": "^1.0.0"
+            }
+        },
+        "opn": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/opn/-/opn-5.2.0.tgz",
+            "integrity": "sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==",
+            "dev": true,
+            "requires": {
+                "is-wsl": "^1.1.0"
+            }
+        },
+        "optionator": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+            "dev": true,
+            "requires": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
+            }
+        },
+        "ora": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-2.1.0.tgz",
+            "integrity": "sha512-hNNlAd3gfv/iPmsNxYoAPLvxg7HuPozww7fFonMZvL84tP6Ox5igfk5j/+a9rtJJwqMgKK+JgWsAQik5o0HTLA==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.3.1",
+                "cli-cursor": "^2.1.0",
+                "cli-spinners": "^1.1.0",
+                "log-symbols": "^2.2.0",
+                "strip-ansi": "^4.0.0",
+                "wcwidth": "^1.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "original": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+            "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+            "dev": true,
+            "requires": {
+                "url-parse": "^1.4.3"
+            }
+        },
+        "os-browserify": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+            "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+            "dev": true
+        },
+        "os-homedir": {
+            "version": "1.0.2",
+            "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "dev": true
+        },
+        "os-locale": {
+            "version": "1.4.0",
+            "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+            "dev": true,
+            "requires": {
+                "lcid": "^1.0.0"
+            }
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
+        },
+        "osenv": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+            "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+            "dev": true,
+            "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+            }
+        },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+            "dev": true
+        },
+        "p-limit": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+            "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+            "dev": true,
+            "requires": {
+                "p-try": "^1.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "dev": true,
+            "requires": {
+                "p-limit": "^1.1.0"
+            }
+        },
+        "p-map": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+            "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+            "dev": true
+        },
+        "p-try": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+            "dev": true
+        },
+        "package-json": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+            "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+            "dev": true,
+            "requires": {
+                "got": "^6.7.1",
+                "registry-auth-token": "^3.0.1",
+                "registry-url": "^3.0.3",
+                "semver": "^5.1.0"
+            }
+        },
+        "pako": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+            "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+            "dev": true
+        },
+        "parallel-transform": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+            "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+            "dev": true,
+            "requires": {
+                "cyclist": "~0.2.2",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.1.5"
+            }
+        },
+        "param-case": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+            "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+            "dev": true,
+            "requires": {
+                "no-case": "^2.2.0"
+            }
+        },
+        "parse-asn1": {
+            "version": "5.1.1",
+            "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+            "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
+            "dev": true,
+            "requires": {
+                "asn1.js": "^4.0.0",
+                "browserify-aes": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.0",
+                "pbkdf2": "^3.0.3"
+            }
+        },
+        "parse-entities": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.0.tgz",
+            "integrity": "sha512-XXtDdOPLSB0sHecbEapQi6/58U/ODj/KWfIXmmMCJF/eRn8laX6LZbOyioMoETOOJoWRW8/qTSl5VQkUIfKM5g==",
+            "dev": true,
+            "requires": {
+                "character-entities": "^1.0.0",
+                "character-entities-legacy": "^1.0.0",
+                "character-reference-invalid": "^1.0.0",
+                "is-alphanumerical": "^1.0.0",
+                "is-decimal": "^1.0.0",
+                "is-hexadecimal": "^1.0.0"
+            }
+        },
+        "parse-glob": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+            "dev": true,
+            "requires": {
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
+            },
+            "dependencies": {
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "parse-json": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+            "dev": true,
+            "requires": {
+                "error-ex": "^1.2.0"
+            }
+        },
+        "parse-passwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+            "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+            "dev": true
+        },
+        "parse5": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+            "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "parseurl": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+            "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+            "dev": true
+        },
+        "pascalcase": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+            "dev": true
+        },
+        "path-browserify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+            "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+            "dev": true
+        },
+        "path-dirname": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+            "dev": true
+        },
+        "path-exists": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-is-inside": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+            "dev": true
+        },
+        "path-key": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+            "dev": true
+        },
+        "path-to-regexp": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+            "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+            "dev": true
+        },
+        "path-type": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+            "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                }
+            }
+        },
+        "pathval": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+            "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+            "dev": true
+        },
+        "pause-stream": {
+            "version": "0.0.11",
+            "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+            "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+            "dev": true,
+            "requires": {
+                "through": "~2.3"
+            }
+        },
+        "pbkdf2": {
+            "version": "3.0.17",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
+            "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+            "dev": true,
+            "requires": {
+                "create-hash": "^1.1.2",
+                "create-hmac": "^1.1.4",
+                "ripemd160": "^2.0.1",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
+            }
+        },
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "dev": true
+        },
+        "phantomjs-polyfill-object-assign": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/phantomjs-polyfill-object-assign/-/phantomjs-polyfill-object-assign-0.0.2.tgz",
+            "integrity": "sha1-gymlx/eeAiUvp+/Da27QVdaC7ZE=",
+            "dev": true
+        },
+        "pify": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+            "dev": true
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
+            "requires": {
+                "pinkie": "^2.0.0"
+            }
+        },
+        "pkg-dir": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+            "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+            "dev": true,
+            "requires": {
+                "find-up": "^2.1.0"
+            }
+        },
+        "pluralize": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+            "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+            "dev": true
+        },
+        "pn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+            "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+            "dev": true
+        },
+        "portfinder": {
+            "version": "1.0.19",
+            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.19.tgz",
+            "integrity": "sha512-23aeQKW9KgHe6citUrG3r9HjeX6vls0h713TAa+CwTKZwNIr/pD2ApaxYF4Um3ZZyq4ar+Siv3+fhoHaIwSOSw==",
+            "dev": true,
+            "requires": {
+                "async": "^1.5.2",
+                "debug": "^2.2.0",
+                "mkdirp": "0.5.x"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.5.2",
+                    "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                    "dev": true
+                }
+            }
+        },
+        "posix-character-classes": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+            "dev": true
+        },
+        "postcss": {
+            "version": "5.2.18",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+            "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "supports-color": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                            "dev": true
+                        }
+                    }
+                },
+                "has-flag": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "3.2.3",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "postcss-calc": {
+            "version": "5.3.1",
+            "resolved": "http://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+            "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
+            "dev": true,
+            "requires": {
+                "postcss": "^5.0.2",
+                "postcss-message-helpers": "^2.0.0",
+                "reduce-css-calc": "^1.2.6"
+            }
+        },
+        "postcss-colormin": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+            "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
+            "dev": true,
+            "requires": {
+                "colormin": "^1.0.5",
+                "postcss": "^5.0.13",
+                "postcss-value-parser": "^3.2.3"
+            }
+        },
+        "postcss-convert-values": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
+            "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
+            "dev": true,
+            "requires": {
+                "postcss": "^5.0.11",
+                "postcss-value-parser": "^3.1.2"
+            }
+        },
+        "postcss-discard-comments": {
+            "version": "2.0.4",
+            "resolved": "http://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+            "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
+            "dev": true,
+            "requires": {
+                "postcss": "^5.0.14"
+            }
+        },
+        "postcss-discard-duplicates": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
+            "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
+            "dev": true,
+            "requires": {
+                "postcss": "^5.0.4"
+            }
+        },
+        "postcss-discard-empty": {
+            "version": "2.1.0",
+            "resolved": "http://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+            "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
+            "dev": true,
+            "requires": {
+                "postcss": "^5.0.14"
+            }
+        },
+        "postcss-discard-overridden": {
+            "version": "0.1.1",
+            "resolved": "http://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+            "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
+            "dev": true,
+            "requires": {
+                "postcss": "^5.0.16"
+            }
+        },
+        "postcss-discard-unused": {
+            "version": "2.2.3",
+            "resolved": "http://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+            "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
+            "dev": true,
+            "requires": {
+                "postcss": "^5.0.14",
+                "uniqs": "^2.0.0"
+            }
+        },
+        "postcss-filter-plugins": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.3.tgz",
+            "integrity": "sha512-T53GVFsdinJhgwm7rg1BzbeBRomOg9y5MBVhGcsV0CxurUdVj1UlPdKtn7aqYA/c/QVkzKMjq2bSV5dKG5+AwQ==",
+            "dev": true,
+            "requires": {
+                "postcss": "^5.0.4"
+            }
+        },
+        "postcss-merge-idents": {
+            "version": "2.1.7",
+            "resolved": "http://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+            "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.1",
+                "postcss": "^5.0.10",
+                "postcss-value-parser": "^3.1.1"
+            }
+        },
+        "postcss-merge-longhand": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
+            "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
+            "dev": true,
+            "requires": {
+                "postcss": "^5.0.4"
+            }
+        },
+        "postcss-merge-rules": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+            "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
+            "dev": true,
+            "requires": {
+                "browserslist": "^1.5.2",
+                "caniuse-api": "^1.5.2",
+                "postcss": "^5.0.4",
+                "postcss-selector-parser": "^2.2.2",
+                "vendors": "^1.0.0"
+            }
+        },
+        "postcss-message-helpers": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+            "integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=",
+            "dev": true
+        },
+        "postcss-minify-font-values": {
+            "version": "1.0.5",
+            "resolved": "http://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+            "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
+            "dev": true,
+            "requires": {
+                "object-assign": "^4.0.1",
+                "postcss": "^5.0.4",
+                "postcss-value-parser": "^3.0.2"
+            }
+        },
+        "postcss-minify-gradients": {
+            "version": "1.0.5",
+            "resolved": "http://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+            "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
+            "dev": true,
+            "requires": {
+                "postcss": "^5.0.12",
+                "postcss-value-parser": "^3.3.0"
+            }
+        },
+        "postcss-minify-params": {
+            "version": "1.2.2",
+            "resolved": "http://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+            "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
+            "dev": true,
+            "requires": {
+                "alphanum-sort": "^1.0.1",
+                "postcss": "^5.0.2",
+                "postcss-value-parser": "^3.0.2",
+                "uniqs": "^2.0.0"
+            }
+        },
+        "postcss-minify-selectors": {
+            "version": "2.1.1",
+            "resolved": "http://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+            "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
+            "dev": true,
+            "requires": {
+                "alphanum-sort": "^1.0.2",
+                "has": "^1.0.1",
+                "postcss": "^5.0.14",
+                "postcss-selector-parser": "^2.0.0"
+            }
+        },
+        "postcss-modules-extract-imports": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
+            "integrity": "sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==",
+            "dev": true,
+            "requires": {
+                "postcss": "^6.0.1"
+            },
+            "dependencies": {
+                "postcss": {
+                    "version": "6.0.23",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "postcss-modules-local-by-default": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+            "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+            "dev": true,
+            "requires": {
+                "css-selector-tokenizer": "^0.7.0",
+                "postcss": "^6.0.1"
+            },
+            "dependencies": {
+                "postcss": {
+                    "version": "6.0.23",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "postcss-modules-scope": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+            "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+            "dev": true,
+            "requires": {
+                "css-selector-tokenizer": "^0.7.0",
+                "postcss": "^6.0.1"
+            },
+            "dependencies": {
+                "postcss": {
+                    "version": "6.0.23",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "postcss-modules-values": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+            "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+            "dev": true,
+            "requires": {
+                "icss-replace-symbols": "^1.1.0",
+                "postcss": "^6.0.1"
+            },
+            "dependencies": {
+                "postcss": {
+                    "version": "6.0.23",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "postcss-normalize-charset": {
+            "version": "1.1.1",
+            "resolved": "http://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+            "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
+            "dev": true,
+            "requires": {
+                "postcss": "^5.0.5"
+            }
+        },
+        "postcss-normalize-url": {
+            "version": "3.0.8",
+            "resolved": "http://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+            "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
+            "dev": true,
+            "requires": {
+                "is-absolute-url": "^2.0.0",
+                "normalize-url": "^1.4.0",
+                "postcss": "^5.0.14",
+                "postcss-value-parser": "^3.2.3"
+            }
+        },
+        "postcss-ordered-values": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
+            "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
+            "dev": true,
+            "requires": {
+                "postcss": "^5.0.4",
+                "postcss-value-parser": "^3.0.1"
+            }
+        },
+        "postcss-reduce-idents": {
+            "version": "2.4.0",
+            "resolved": "http://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+            "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
+            "dev": true,
+            "requires": {
+                "postcss": "^5.0.4",
+                "postcss-value-parser": "^3.0.2"
+            }
+        },
+        "postcss-reduce-initial": {
+            "version": "1.0.1",
+            "resolved": "http://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+            "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
+            "dev": true,
+            "requires": {
+                "postcss": "^5.0.4"
+            }
+        },
+        "postcss-reduce-transforms": {
+            "version": "1.0.4",
+            "resolved": "http://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+            "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.1",
+                "postcss": "^5.0.8",
+                "postcss-value-parser": "^3.0.1"
+            }
+        },
+        "postcss-selector-parser": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+            "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+            "dev": true,
+            "requires": {
+                "flatten": "^1.0.2",
+                "indexes-of": "^1.0.1",
+                "uniq": "^1.0.1"
+            }
+        },
+        "postcss-svgo": {
+            "version": "2.1.6",
+            "resolved": "http://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+            "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
+            "dev": true,
+            "requires": {
+                "is-svg": "^2.0.0",
+                "postcss": "^5.0.14",
+                "postcss-value-parser": "^3.2.3",
+                "svgo": "^0.7.0"
+            }
+        },
+        "postcss-unique-selectors": {
+            "version": "2.0.2",
+            "resolved": "http://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+            "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
+            "dev": true,
+            "requires": {
+                "alphanum-sort": "^1.0.1",
+                "postcss": "^5.0.4",
+                "uniqs": "^2.0.0"
+            }
+        },
+        "postcss-value-parser": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+            "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+            "dev": true
+        },
+        "postcss-zindex": {
+            "version": "2.2.0",
+            "resolved": "http://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+            "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.1",
+                "postcss": "^5.0.4",
+                "uniqs": "^2.0.0"
+            }
+        },
+        "prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "dev": true
+        },
+        "prepend-http": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+            "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+            "dev": true
+        },
+        "preserve": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+            "dev": true
+        },
+        "pretty-error": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
+            "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
+            "dev": true,
+            "requires": {
+                "renderkid": "^2.0.1",
+                "utila": "~0.4"
+            }
+        },
+        "private": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+            "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+            "dev": true
+        },
+        "process": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+            "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
+            "dev": true
+        },
+        "process-nextick-args": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+            "dev": true
+        },
+        "progress": {
+            "version": "1.1.8",
+            "resolved": "http://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+            "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+            "dev": true
+        },
+        "promise-inflight": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+            "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+            "dev": true
+        },
+        "prop-types": {
+            "version": "15.6.2",
+            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+            "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.3.1",
+                "object-assign": "^4.1.1"
+            }
+        },
+        "proxy-addr": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+            "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+            "dev": true,
+            "requires": {
+                "forwarded": "~0.1.2",
+                "ipaddr.js": "1.8.0"
+            }
+        },
+        "prr": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+            "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+            "dev": true
+        },
+        "ps-tree": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
+            "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
+            "dev": true,
+            "requires": {
+                "event-stream": "~3.3.0"
+            }
+        },
+        "pseudomap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+            "dev": true
+        },
+        "psl": {
+            "version": "1.1.29",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+            "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+            "dev": true
+        },
+        "pstree.remy": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.0.tgz",
+            "integrity": "sha512-q5I5vLRMVtdWa8n/3UEzZX7Lfghzrg9eG2IKk2ENLSofKRCXVqMvMUHxCKgXNaqH/8ebhBxrqftHWnyTFweJ5Q==",
+            "dev": true,
+            "requires": {
+                "ps-tree": "^1.1.0"
+            }
+        },
+        "public-encrypt": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+            "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.1.0",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "parse-asn1": "^5.0.0",
+                "randombytes": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            }
+        },
+        "pump": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "pumpify": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+            "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+            "dev": true,
+            "requires": {
+                "duplexify": "^3.6.0",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
+            }
+        },
+        "punycode": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "dev": true
+        },
+        "q": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+            "dev": true
+        },
+        "q-i": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/q-i/-/q-i-2.0.1.tgz",
+            "integrity": "sha512-tr7CzPNxkBDBuPzqi/HDUS4uBOppb91akNTeh56TYio8TiIeXp2Yp8ea9NmDu2DmGH35ZjJDq6C3E4SepVZ4bQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.0",
+                "is-plain-object": "^2.0.4",
+                "stringify-object": "^3.2.0"
+            },
+            "dependencies": {
+                "stringify-object": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+                    "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+                    "dev": true,
+                    "requires": {
+                        "get-own-enumerable-property-symbols": "^3.0.0",
+                        "is-obj": "^1.0.1",
+                        "is-regexp": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "qs": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+            "dev": true
+        },
+        "query-string": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+            "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+            "dev": true,
+            "requires": {
+                "object-assign": "^4.1.0",
+                "strict-uri-encode": "^1.0.0"
+            }
+        },
+        "querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "dev": true
+        },
+        "querystring-es3": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+            "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+            "dev": true
+        },
+        "querystringify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
+            "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==",
+            "dev": true
+        },
+        "raf": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+            "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+            "dev": true,
+            "requires": {
+                "performance-now": "^2.1.0"
+            }
+        },
+        "railroad-diagrams": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+            "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
+            "dev": true
+        },
+        "randexp": {
+            "version": "0.4.6",
+            "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+            "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+            "dev": true,
+            "requires": {
+                "discontinuous-range": "1.0.0",
+                "ret": "~0.1.10"
+            }
+        },
+        "randomatic": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+            "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+            "dev": true,
+            "requires": {
+                "is-number": "^4.0.0",
+                "kind-of": "^6.0.0",
+                "math-random": "^1.0.1"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
+                }
+            }
+        },
+        "randombytes": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+            "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.1.0"
+            }
+        },
+        "randomfill": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+            "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+            "dev": true,
+            "requires": {
+                "randombytes": "^2.0.5",
+                "safe-buffer": "^5.1.0"
+            }
+        },
+        "range-parser": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+            "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+            "dev": true
+        },
+        "raw-body": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+            "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+            "dev": true,
+            "requires": {
+                "bytes": "3.0.0",
+                "http-errors": "1.6.3",
+                "iconv-lite": "0.4.23",
+                "unpipe": "1.0.0"
+            },
+            "dependencies": {
+                "iconv-lite": {
+                    "version": "0.4.23",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+                    "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+                    "dev": true,
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
+                }
+            }
+        },
+        "rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "dev": true,
+            "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
+            }
+        },
+        "react": {
+            "version": "16.6.3",
+            "resolved": "https://registry.npmjs.org/react/-/react-16.6.3.tgz",
+            "integrity": "sha512-zCvmH2vbEolgKxtqXL2wmGCUxUyNheYn/C+PD1YAjfxHC54+MhdruyhO7QieQrYsYeTxrn93PM2y0jRH1zEExw==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2",
+                "scheduler": "^0.11.2"
+            }
+        },
+        "react-codemirror2": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-5.1.0.tgz",
+            "integrity": "sha512-Cksbgbviuf2mJfMyrKmcu7ycK6zX/ukuQO8dvRZdFWqATf5joalhjFc6etnBdGCcPA2LbhIwz+OPnQxLN/j1Fw==",
+            "dev": true
+        },
+        "react-dev-utils": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-5.0.3.tgz",
+            "integrity": "sha512-Mvs6ofsc2xTjeZIrMaIfbXfsPVrbdVy/cVqq6SAacnqfMlcBpDuivhWZ1ODGeJ8HgmyWTLH971PYjj/EPCDVAw==",
+            "dev": true,
+            "requires": {
+                "address": "1.0.3",
+                "babel-code-frame": "6.26.0",
+                "chalk": "1.1.3",
+                "cross-spawn": "5.1.0",
+                "detect-port-alt": "1.1.6",
+                "escape-string-regexp": "1.0.5",
+                "filesize": "3.5.11",
+                "global-modules": "1.0.0",
+                "gzip-size": "3.0.0",
+                "inquirer": "3.3.0",
+                "is-root": "1.0.0",
+                "opn": "5.2.0",
+                "react-error-overlay": "^4.0.1",
+                "recursive-readdir": "2.2.1",
+                "shell-quote": "1.6.1",
+                "sockjs-client": "1.1.5",
+                "strip-ansi": "3.0.1",
+                "text-table": "0.2.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                    "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "react-docgen": {
+            "version": "3.0.0-beta12",
+            "resolved": "http://registry.npmjs.org/react-docgen/-/react-docgen-3.0.0-beta12.tgz",
+            "integrity": "sha512-8DE3R6mPJSpBS2k6nw4hyZ/E+k60tE/AzLe/ncfyf3AQnd1pojo8cCn2ziXU33Vfny5u7G0pCrL01h9rcX6MTw==",
+            "dev": true,
+            "requires": {
+                "async": "^2.1.4",
+                "babel-runtime": "^6.9.2",
+                "babylon": "7.0.0-beta.40",
+                "commander": "^2.9.0",
+                "doctrine": "^2.0.0",
+                "node-dir": "^0.1.10",
+                "recast": "^0.13.0"
+            },
+            "dependencies": {
+                "babylon": {
+                    "version": "7.0.0-beta.40",
+                    "resolved": "http://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
+                    "integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+                    "dev": true
+                }
+            }
+        },
+        "react-docgen-annotation-resolver": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/react-docgen-annotation-resolver/-/react-docgen-annotation-resolver-1.1.0.tgz",
+            "integrity": "sha512-wTUI7IqWkV+BNRmEh1eHkU+Ijwh0XcFUdbgktynWVqe++MgtovdlbfMehFAw5b49mv8NN2DK0NF/G8x+UdIyNw==",
+            "dev": true
+        },
+        "react-docgen-displayname-handler": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/react-docgen-displayname-handler/-/react-docgen-displayname-handler-2.1.1.tgz",
+            "integrity": "sha512-Dmu+WnQt5TRDokaQ6uGvgcxrIh92c6uhuljsuueEphTcy/1nKh8/Ep6RUmpd77G1iN2rqg5+4ztGAT7LJjVdpg==",
+            "dev": true,
+            "requires": {
+                "ast-types": "0.11.5"
+            },
+            "dependencies": {
+                "ast-types": {
+                    "version": "0.11.5",
+                    "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.5.tgz",
+                    "integrity": "sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw==",
+                    "dev": true
+                }
+            }
+        },
+        "react-docgen-typescript": {
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-1.12.1.tgz",
+            "integrity": "sha512-wrV2YlYgLAw84pvuFl8YYkHetPf35vT5gLMtJH86YiQvuR35dJst+06O25oNLFCpUNw/bB6B3uszRyAKO+SU8Q==",
+            "dev": true
+        },
+        "react-dom": {
+            "version": "16.6.3",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.3.tgz",
+            "integrity": "sha512-8ugJWRCWLGXy+7PmNh8WJz3g1TaTUt1XyoIcFN+x0Zbkoz+KKdUyx1AQLYJdbFXjuF41Nmjn5+j//rxvhFjgSQ==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2",
+                "scheduler": "^0.11.2"
+            }
+        },
+        "react-element-to-jsx-string": {
+            "version": "5.0.7",
+            "resolved": "http://registry.npmjs.org/react-element-to-jsx-string/-/react-element-to-jsx-string-5.0.7.tgz",
+            "integrity": "sha1-xmOkgAqccSEVwNhRnLAhWkah8PI=",
+            "dev": true,
+            "requires": {
+                "collapse-white-space": "^1.0.0",
+                "is-plain-object": "^2.0.1",
+                "lodash": "^4.17.4",
+                "sortobject": "^1.0.0",
+                "stringify-object": "2.4.0",
+                "traverse": "^0.6.6"
+            }
+        },
+        "react-error-overlay": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-4.0.1.tgz",
+            "integrity": "sha512-xXUbDAZkU08aAkjtUvldqbvI04ogv+a1XdHxvYuHPYKIVk/42BIOD0zSKTHAWV4+gDy3yGm283z2072rA2gdtw==",
+            "dev": true
+        },
+        "react-group": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/react-group/-/react-group-1.0.6.tgz",
+            "integrity": "sha1-jdfADDs10FzhZAIUWLsH1YDjABo=",
+            "dev": true,
+            "requires": {
+                "prop-types": "^15.6.0"
+            }
+        },
+        "react-hot-loader": {
+            "version": "4.3.12",
+            "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.3.12.tgz",
+            "integrity": "sha512-GMM4TsqUVss2QPe+Y33NlgydA5/+7tAVQxR0rZqWvBpapM8JhD7p6ymMwSZzr5yxjoXXlK/6P6qNQBOqm1dqdg==",
+            "dev": true,
+            "requires": {
+                "fast-levenshtein": "^2.0.6",
+                "global": "^4.3.0",
+                "hoist-non-react-statics": "^2.5.0",
+                "prop-types": "^15.6.1",
+                "react-lifecycles-compat": "^3.0.4",
+                "shallowequal": "^1.0.2"
+            }
+        },
+        "react-icon-base": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/react-icon-base/-/react-icon-base-2.1.0.tgz",
+            "integrity": "sha1-oZbjP98eeqof2jrvu2i9rZ6Cp50=",
+            "dev": true
+        },
+        "react-icons": {
+            "version": "2.2.7",
+            "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-2.2.7.tgz",
+            "integrity": "sha512-0n4lcGqzJFcIQLoQytLdJCE0DKSA9dkwEZRYoGrIDJZFvIT6Hbajx5mv9geqhqFiNjUgtxg8kPyDfjlhymbGFg==",
+            "dev": true,
+            "requires": {
+                "react-icon-base": "2.1.0"
+            }
+        },
+        "react-is": {
+            "version": "16.6.3",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.3.tgz",
+            "integrity": "sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA==",
+            "dev": true
+        },
+        "react-lifecycles-compat": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+            "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+            "dev": true
+        },
+        "react-styleguidist": {
+            "version": "7.3.11",
+            "resolved": "https://registry.npmjs.org/react-styleguidist/-/react-styleguidist-7.3.11.tgz",
+            "integrity": "sha512-Y1zgWG1R6NFmScBFIviSnt9vpsQzxriyZPe4AK224Z66PfyhXPBIgbXCqn1zTeOcic7/n0g9pp/K6I0ANecuIg==",
+            "dev": true,
+            "requires": {
+                "@vxna/mini-html-webpack-template": "^0.1.7",
+                "acorn": "^5.7.1",
+                "ast-types": "^0.11.5",
+                "buble": "0.19.4",
+                "classnames": "^2.2.6",
+                "clean-webpack-plugin": "^0.1.19",
+                "clipboard-copy": "^2.0.0",
+                "codemirror": "^5.39.0",
+                "common-dir": "^2.0.2",
+                "copy-webpack-plugin": "^4.5.2",
+                "css-loader": "^0.28.11",
+                "doctrine": "^2.1.0",
+                "es6-object-assign": "~1.1.0",
+                "es6-promise": "^4.2.4",
+                "escodegen": "^1.10.0",
+                "findup": "^0.1.5",
+                "function.name-polyfill": "^1.0.6",
+                "github-slugger": "^1.2.0",
+                "glob": "^7.1.2",
+                "glogg": "^1.0.1",
+                "highlight.js": "^9.12.0",
+                "is-directory": "^0.3.1",
+                "javascript-stringify": "^1.6.0",
+                "jss": "^9.8.7",
+                "jss-camel-case": "^6.1.0",
+                "jss-compose": "^5.0.0",
+                "jss-default-unit": "^8.0.2",
+                "jss-global": "^3.0.0",
+                "jss-isolate": "^5.1.0",
+                "jss-nested": "^6.0.1",
+                "kleur": "^2.0.1",
+                "leven": "^2.1.0",
+                "listify": "^1.0.0",
+                "loader-utils": "^1.1.0",
+                "lodash": "^4.17.10",
+                "lowercase-keys": "^1.0.1",
+                "markdown-to-jsx": "^6.6.8",
+                "mini-html-webpack-plugin": "^0.2.3",
+                "minimist": "^1.2.0",
+                "ora": "^2.1.0",
+                "prop-types": "^15.6.2",
+                "q-i": "^2.0.1",
+                "react-codemirror2": "^5.1.0",
+                "react-dev-utils": "^5.0.1",
+                "react-docgen": "3.0.0-beta12",
+                "react-docgen-annotation-resolver": "^1.0.0",
+                "react-docgen-displayname-handler": "^2.1.0",
+                "react-group": "^1.0.6",
+                "react-icons": "^2.2.7",
+                "react-lifecycles-compat": "^3.0.4",
+                "recast": "^0.13.0",
+                "remark": "^9.0.0",
+                "style-loader": "^0.21.0",
+                "to-ast": "^1.0.0",
+                "type-detect": "^4.0.8",
+                "uglifyjs-webpack-plugin": "1.2.7",
+                "unist-util-visit": "^1.3.1",
+                "webpack-dev-server": "^2.11.2",
+                "webpack-merge": "^4.1.3"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.7.3",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+                    "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+                    "dev": true
+                },
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                },
+                "style-loader": {
+                    "version": "0.21.0",
+                    "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.21.0.tgz",
+                    "integrity": "sha512-T+UNsAcl3Yg+BsPKs1vd22Fr8sVT+CJMtzqc6LEw9bbJZb43lm9GoeIfUcDEefBSWC0BhYbcdupV1GtI4DGzxg==",
+                    "dev": true,
+                    "requires": {
+                        "loader-utils": "^1.1.0",
+                        "schema-utils": "^0.4.5"
+                    }
+                }
+            }
+        },
+        "react-test-renderer": {
+            "version": "16.6.3",
+            "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.6.3.tgz",
+            "integrity": "sha512-B5bCer+qymrQz/wN03lT0LppbZUDRq6AMfzMKrovzkGzfO81a9T+PWQW6MzkWknbwODQH/qpJno/yFQLX5IWrQ==",
+            "dev": true,
+            "requires": {
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2",
+                "react-is": "^16.6.3",
+                "scheduler": "^0.11.2"
+            }
+        },
+        "read-pkg": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+            "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+            "dev": true,
+            "requires": {
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
+            }
+        },
+        "read-pkg-up": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+            "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+            "dev": true,
+            "requires": {
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                    "dev": true,
+                    "requires": {
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                    "dev": true,
+                    "requires": {
+                        "pinkie-promise": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "readable-stream": {
+            "version": "2.3.6",
+            "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "dev": true,
+            "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "readdirp": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+            "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "micromatch": "^3.1.10",
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "readline2": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+            "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+            "dev": true,
+            "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "mute-stream": "0.0.5"
+            },
+            "dependencies": {
+                "mute-stream": {
+                    "version": "0.0.5",
+                    "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+                    "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+                    "dev": true
+                }
+            }
+        },
+        "recast": {
+            "version": "0.13.2",
+            "resolved": "http://registry.npmjs.org/recast/-/recast-0.13.2.tgz",
+            "integrity": "sha512-Xqo0mKljGUWGUhnkdbODk7oJGFrMcpgKQ9cCyZ4y+G9VfoTKdum8nHbf/SxIdKx5aBSZ29VpVy20bTyt7jyC8w==",
+            "dev": true,
+            "requires": {
+                "ast-types": "0.10.2",
+                "esprima": "~4.0.0",
+                "private": "~0.1.5",
+                "source-map": "~0.6.1"
+            },
+            "dependencies": {
+                "ast-types": {
+                    "version": "0.10.2",
+                    "resolved": "http://registry.npmjs.org/ast-types/-/ast-types-0.10.2.tgz",
+                    "integrity": "sha512-ufWX953VU1eIuWqxS0nRDMYlGyFH+yxln5CsmIHlpzEt3fdYqUnRtsFt0XAsQot8OaVCwFqxT1RiwvtzYjeYeg==",
+                    "dev": true
+                },
+                "esprima": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+                    "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "recursive-readdir": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.1.tgz",
+            "integrity": "sha1-kO8jHQd4xc4JPJpI105cVCLROpk=",
+            "dev": true,
+            "requires": {
+                "minimatch": "3.0.3"
+            },
+            "dependencies": {
+                "minimatch": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                    "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "redent": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+            "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+            "dev": true,
+            "requires": {
+                "indent-string": "^2.1.0",
+                "strip-indent": "^1.0.1"
+            }
+        },
+        "reduce-css-calc": {
+            "version": "1.3.0",
+            "resolved": "http://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+            "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^0.4.2",
+                "math-expression-evaluator": "^1.2.14",
+                "reduce-function-call": "^1.0.1"
+            },
+            "dependencies": {
+                "balanced-match": {
+                    "version": "0.4.2",
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                    "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                    "dev": true
+                }
+            }
+        },
+        "reduce-function-call": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
+            "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^0.4.2"
+            },
+            "dependencies": {
+                "balanced-match": {
+                    "version": "0.4.2",
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                    "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                    "dev": true
+                }
+            }
+        },
+        "regenerate": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+            "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+            "dev": true
+        },
+        "regenerate-unicode-properties": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
+            "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+            "dev": true,
+            "requires": {
+                "regenerate": "^1.4.0"
+            }
+        },
+        "regenerator-runtime": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+            "dev": true
+        },
+        "regenerator-transform": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+            "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "^6.18.0",
+                "babel-types": "^6.19.0",
+                "private": "^0.1.6"
+            }
+        },
+        "regex-cache": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+            "dev": true,
+            "requires": {
+                "is-equal-shallow": "^0.1.3"
+            }
+        },
+        "regex-not": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+            "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
+            }
+        },
+        "regexpu-core": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+            "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+            "dev": true,
+            "requires": {
+                "regenerate": "^1.2.1",
+                "regjsgen": "^0.2.0",
+                "regjsparser": "^0.1.4"
+            }
+        },
+        "registry-auth-token": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+            "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+            "dev": true,
+            "requires": {
+                "rc": "^1.1.6",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "registry-url": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+            "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+            "dev": true,
+            "requires": {
+                "rc": "^1.0.1"
+            }
+        },
+        "regjsgen": {
+            "version": "0.2.0",
+            "resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+            "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+            "dev": true
+        },
+        "regjsparser": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+            "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+            "dev": true,
+            "requires": {
+                "jsesc": "~0.5.0"
+            },
+            "dependencies": {
+                "jsesc": {
+                    "version": "0.5.0",
+                    "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+                    "dev": true
+                }
+            }
+        },
+        "relateurl": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+            "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+            "dev": true
+        },
+        "remark": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/remark/-/remark-9.0.0.tgz",
+            "integrity": "sha512-amw8rGdD5lHbMEakiEsllmkdBP+/KpjW/PRK6NSGPZKCQowh0BT4IWXDAkRMyG3SB9dKPXWMviFjNusXzXNn3A==",
+            "dev": true,
+            "requires": {
+                "remark-parse": "^5.0.0",
+                "remark-stringify": "^5.0.0",
+                "unified": "^6.0.0"
+            }
+        },
+        "remark-parse": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
+            "integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
+            "dev": true,
+            "requires": {
+                "collapse-white-space": "^1.0.2",
+                "is-alphabetical": "^1.0.0",
+                "is-decimal": "^1.0.0",
+                "is-whitespace-character": "^1.0.0",
+                "is-word-character": "^1.0.0",
+                "markdown-escapes": "^1.0.0",
+                "parse-entities": "^1.1.0",
+                "repeat-string": "^1.5.4",
+                "state-toggle": "^1.0.0",
+                "trim": "0.0.1",
+                "trim-trailing-lines": "^1.0.0",
+                "unherit": "^1.0.4",
+                "unist-util-remove-position": "^1.0.0",
+                "vfile-location": "^2.0.0",
+                "xtend": "^4.0.1"
+            }
+        },
+        "remark-stringify": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-5.0.0.tgz",
+            "integrity": "sha512-Ws5MdA69ftqQ/yhRF9XhVV29mhxbfGhbz0Rx5bQH+oJcNhhSM6nCu1EpLod+DjrFGrU0BMPs+czVmJZU7xiS7w==",
+            "dev": true,
+            "requires": {
+                "ccount": "^1.0.0",
+                "is-alphanumeric": "^1.0.0",
+                "is-decimal": "^1.0.0",
+                "is-whitespace-character": "^1.0.0",
+                "longest-streak": "^2.0.1",
+                "markdown-escapes": "^1.0.0",
+                "markdown-table": "^1.1.0",
+                "mdast-util-compact": "^1.0.0",
+                "parse-entities": "^1.0.2",
+                "repeat-string": "^1.5.4",
+                "state-toggle": "^1.0.0",
+                "stringify-entities": "^1.0.1",
+                "unherit": "^1.0.4",
+                "xtend": "^4.0.1"
+            }
+        },
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+            "dev": true
+        },
+        "renderkid": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.2.tgz",
+            "integrity": "sha512-FsygIxevi1jSiPY9h7vZmBFUbAOcbYm9UwyiLNdVsLRs/5We9Ob5NMPbGYUTWiLq5L+ezlVdE0A8bbME5CWTpg==",
+            "dev": true,
+            "requires": {
+                "css-select": "^1.1.0",
+                "dom-converter": "~0.2",
+                "htmlparser2": "~3.3.0",
+                "strip-ansi": "^3.0.0",
+                "utila": "^0.4.0"
+            },
+            "dependencies": {
+                "domhandler": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
+                    "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
+                    "dev": true,
+                    "requires": {
+                        "domelementtype": "1"
+                    }
+                },
+                "domutils": {
+                    "version": "1.1.6",
+                    "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
+                    "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
+                    "dev": true,
+                    "requires": {
+                        "domelementtype": "1"
+                    }
+                },
+                "htmlparser2": {
+                    "version": "3.3.0",
+                    "resolved": "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
+                    "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
+                    "dev": true,
+                    "requires": {
+                        "domelementtype": "1",
+                        "domhandler": "2.1",
+                        "domutils": "1.1",
+                        "readable-stream": "1.0"
+                    }
+                },
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "1.0.34",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "~0.10.x"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                }
+            }
+        },
+        "repeat-element": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+            "dev": true
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+            "dev": true
+        },
+        "repeating": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+            "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+            "dev": true,
+            "requires": {
+                "is-finite": "^1.0.0"
+            }
+        },
+        "replace-ext": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+            "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+            "dev": true
+        },
+        "request": {
+            "version": "2.88.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+            "dev": true,
+            "requires": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            }
+        },
+        "request-promise-core": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+            "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.13.1"
+            }
+        },
+        "request-promise-native": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+            "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+            "dev": true,
+            "requires": {
+                "request-promise-core": "1.1.1",
+                "stealthy-require": "^1.1.0",
+                "tough-cookie": ">=2.3.3"
+            }
+        },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
+        },
+        "require-main-filename": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+            "dev": true
+        },
+        "require-uncached": {
+            "version": "1.0.3",
+            "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+            "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+            "dev": true,
+            "requires": {
+                "caller-path": "^0.1.0",
+                "resolve-from": "^1.0.0"
+            },
+            "dependencies": {
+                "resolve-from": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+                    "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+                    "dev": true
+                }
+            }
+        },
+        "requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+            "dev": true
+        },
+        "resolve": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+            "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+            "dev": true,
+            "requires": {
+                "path-parse": "^1.0.5"
+            }
+        },
+        "resolve-cwd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+            "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+            "dev": true,
+            "requires": {
+                "resolve-from": "^3.0.0"
+            }
+        },
+        "resolve-dir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+            "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+            "dev": true,
+            "requires": {
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
+            }
+        },
+        "resolve-from": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+            "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+            "dev": true
+        },
+        "resolve-url": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+            "dev": true
+        },
+        "restore-cursor": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+            "dev": true,
+            "requires": {
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
+            }
+        },
+        "ret": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+            "dev": true
+        },
+        "right-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+            "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+            "dev": true,
+            "requires": {
+                "align-text": "^0.1.1"
+            }
+        },
+        "rimraf": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.0.5"
+            }
+        },
+        "ripemd160": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+            "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+            "dev": true,
+            "requires": {
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
+            }
+        },
+        "rst-selector-parser": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
+            "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
+            "dev": true,
+            "requires": {
+                "lodash.flattendeep": "^4.4.0",
+                "nearley": "^2.7.10"
+            }
+        },
+        "run-async": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+            "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+            "dev": true,
+            "requires": {
+                "is-promise": "^2.1.0"
+            }
+        },
+        "run-queue": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+            "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+            "dev": true,
+            "requires": {
+                "aproba": "^1.1.1"
+            }
+        },
+        "rx-lite": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+            "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+            "dev": true
+        },
+        "rx-lite-aggregates": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+            "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+            "dev": true,
+            "requires": {
+                "rx-lite": "*"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
+        },
+        "safe-regex": {
+            "version": "1.1.0",
+            "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+            "dev": true,
+            "requires": {
+                "ret": "~0.1.10"
+            }
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
+        },
+        "sass-graph": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
+            "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+            "dev": true,
+            "requires": {
+                "glob": "^7.0.0",
+                "lodash": "^4.0.0",
+                "scss-tokenizer": "^0.2.3",
+                "yargs": "^7.0.0"
+            }
+        },
+        "sass-lint": {
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/sass-lint/-/sass-lint-1.12.1.tgz",
+            "integrity": "sha1-Yw9pwhaqIGuCMvsqqQe98zNrbYM=",
+            "dev": true,
+            "requires": {
+                "commander": "^2.8.1",
+                "eslint": "^2.7.0",
+                "front-matter": "2.1.2",
+                "fs-extra": "^3.0.1",
+                "glob": "^7.0.0",
+                "globule": "^1.0.0",
+                "gonzales-pe-sl": "^4.2.3",
+                "js-yaml": "^3.5.4",
+                "known-css-properties": "^0.3.0",
+                "lodash.capitalize": "^4.1.0",
+                "lodash.kebabcase": "^4.0.0",
+                "merge": "^1.2.0",
+                "path-is-absolute": "^1.0.0",
+                "util": "^0.10.3"
+            }
+        },
+        "sass-loader": {
+            "version": "6.0.7",
+            "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-6.0.7.tgz",
+            "integrity": "sha512-JoiyD00Yo1o61OJsoP2s2kb19L1/Y2p3QFcCdWdF6oomBGKVYuZyqHWemRBfQ2uGYsk+CH3eCguXNfpjzlcpaA==",
+            "dev": true,
+            "requires": {
+                "clone-deep": "^2.0.1",
+                "loader-utils": "^1.0.1",
+                "lodash.tail": "^4.1.1",
+                "neo-async": "^2.5.0",
+                "pify": "^3.0.0"
+            }
+        },
+        "sax": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "dev": true
+        },
+        "saxes": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.3.tgz",
+            "integrity": "sha512-Nc5DXc5A+m3rUDtkS+vHlBWKT7mCKjJPyia7f8YMW773hsXVv2wEHQZGE0zs4+5PLwz9U5Sbl/94Cnd9vHV7Bg==",
+            "dev": true,
+            "requires": {
+                "xmlchars": "^1.3.1"
+            }
+        },
+        "scheduler": {
+            "version": "0.11.2",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.2.tgz",
+            "integrity": "sha512-+WCP3s3wOaW4S7C1tl3TEXp4l9lJn0ZK8G3W3WKRWmw77Z2cIFUW2MiNTMHn5sCjxN+t7N43HAOOgMjyAg5hlg==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1"
+            }
+        },
+        "schema-utils": {
+            "version": "0.4.7",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
+            "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.1.0",
+                "ajv-keywords": "^3.1.0"
+            }
+        },
+        "scss-tokenizer": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+            "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+            "dev": true,
+            "requires": {
+                "js-base64": "^2.1.8",
+                "source-map": "^0.4.2"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.4.4",
+                    "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                    "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+                    "dev": true,
+                    "requires": {
+                        "amdefine": ">=0.0.4"
+                    }
+                }
+            }
+        },
+        "select-hose": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+            "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
+            "dev": true
+        },
+        "selfsigned": {
+            "version": "1.10.4",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.4.tgz",
+            "integrity": "sha512-9AukTiDmHXGXWtWjembZ5NDmVvP2695EtpgbCsxCa68w3c88B+alqbmZ4O3hZ4VWGXeGWzEVdvqgAJD8DQPCDw==",
+            "dev": true,
+            "requires": {
+                "node-forge": "0.7.5"
+            }
+        },
+        "semver": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+            "dev": true
+        },
+        "semver-diff": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+            "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+            "dev": true,
+            "requires": {
+                "semver": "^5.0.3"
+            }
+        },
+        "send": {
+            "version": "0.16.2",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+            "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "~1.6.2",
+                "mime": "1.4.1",
+                "ms": "2.0.0",
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.0",
+                "statuses": "~1.4.0"
+            }
+        },
+        "serialize-javascript": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
+            "integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==",
+            "dev": true
+        },
+        "serve-index": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+            "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+            "dev": true,
+            "requires": {
+                "accepts": "~1.3.4",
+                "batch": "0.6.1",
+                "debug": "2.6.9",
+                "escape-html": "~1.0.3",
+                "http-errors": "~1.6.2",
+                "mime-types": "~2.1.17",
+                "parseurl": "~1.3.2"
+            }
+        },
+        "serve-static": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+            "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+            "dev": true,
+            "requires": {
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.2",
+                "send": "0.16.2"
+            }
+        },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
+        },
+        "set-value": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+            "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "setimmediate": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+            "dev": true
+        },
+        "setprototypeof": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+            "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+            "dev": true
+        },
+        "sha.js": {
+            "version": "2.4.11",
+            "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+            "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "shallow-clone": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-1.0.0.tgz",
+            "integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
+            "dev": true,
+            "requires": {
+                "is-extendable": "^0.1.1",
+                "kind-of": "^5.0.0",
+                "mixin-object": "^2.0.1"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
+        },
+        "shallowequal": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+            "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+            "dev": true
+        },
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "^1.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
+        },
+        "shell-quote": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+            "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+            "dev": true,
+            "requires": {
+                "array-filter": "~0.0.0",
+                "array-map": "~0.0.0",
+                "array-reduce": "~0.0.0",
+                "jsonify": "~0.0.0"
+            }
+        },
+        "shelljs": {
+            "version": "0.6.1",
+            "resolved": "http://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+            "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
+            "dev": true
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
+        },
+        "sinon": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.1.1.tgz",
+            "integrity": "sha512-iYagtjLVt1vN3zZY7D8oH7dkjNJEjLjyuzy8daX5+3bbQl8gaohrheB9VfH1O3L6LKuue5WTJvFluHiuZ9y3nQ==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.2.0",
+                "@sinonjs/formatio": "^3.0.0",
+                "@sinonjs/samsam": "^2.1.2",
+                "diff": "^3.5.0",
+                "lodash.get": "^4.4.2",
+                "lolex": "^3.0.0",
+                "nise": "^1.4.6",
+                "supports-color": "^5.5.0",
+                "type-detect": "^4.0.8"
+            }
+        },
+        "sinon-chai": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.2.0.tgz",
+            "integrity": "sha512-Z72B4a0l0IQe5uWi9yzcqX/Ml6K9e1Hp03NmkjJnRG3gDsKTX7KvLFZsVUmCaz0eqeXLLK089mwTsP1P1W+DUQ==",
+            "dev": true
+        },
+        "slash": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+            "dev": true
+        },
+        "slice-ansi": {
+            "version": "0.0.4",
+            "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+            "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+            "dev": true
+        },
+        "snapdragon": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+            "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+            "dev": true,
+            "requires": {
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "snapdragon-node": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+            "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+            "dev": true,
+            "requires": {
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "snapdragon-util": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+            "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.2.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "sockjs": {
+            "version": "0.3.19",
+            "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
+            "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
+            "dev": true,
+            "requires": {
+                "faye-websocket": "^0.10.0",
+                "uuid": "^3.0.1"
+            },
+            "dependencies": {
+                "faye-websocket": {
+                    "version": "0.10.0",
+                    "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+                    "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+                    "dev": true,
+                    "requires": {
+                        "websocket-driver": ">=0.5.1"
+                    }
+                }
+            }
+        },
+        "sockjs-client": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
+            "integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
+            "dev": true,
+            "requires": {
+                "debug": "^2.6.6",
+                "eventsource": "0.1.6",
+                "faye-websocket": "~0.11.0",
+                "inherits": "^2.0.1",
+                "json3": "^3.3.2",
+                "url-parse": "^1.1.8"
+            }
+        },
+        "sort-keys": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+            "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+            "dev": true,
+            "requires": {
+                "is-plain-obj": "^1.0.0"
+            }
+        },
+        "sortobject": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/sortobject/-/sortobject-1.1.1.tgz",
+            "integrity": "sha1-T2ldTUTtCkwGSCw0wlgqLc3CqzQ=",
+            "dev": true,
+            "requires": {
+                "editions": "^1.1.1"
+            }
+        },
+        "source-list-map": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
+            "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
+            "dev": true
+        },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+            "dev": true
+        },
+        "source-map-loader": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.4.tgz",
+            "integrity": "sha512-OU6UJUty+i2JDpTItnizPrlpOIBLmQbWMuBg9q5bVtnHACqw1tn9nNwqJLbv0/00JjnJb/Ee5g5WS5vrRv7zIQ==",
+            "dev": true,
+            "requires": {
+                "async": "^2.5.0",
+                "loader-utils": "^1.1.0"
+            }
+        },
+        "source-map-resolve": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+            "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+            "dev": true,
+            "requires": {
+                "atob": "^2.1.1",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
+            }
+        },
+        "source-map-support": {
+            "version": "0.5.9",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+            "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "source-map-url": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+            "dev": true
+        },
+        "sparkles": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+            "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
+            "dev": true
+        },
+        "spdx-correct": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
+            "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+            "dev": true,
+            "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-exceptions": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+            "dev": true
+        },
+        "spdx-expression-parse": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+            "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "dev": true,
+            "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-license-ids": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
+            "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
+            "dev": true
+        },
+        "spdy": {
+            "version": "3.4.7",
+            "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
+            "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+            "dev": true,
+            "requires": {
+                "debug": "^2.6.8",
+                "handle-thing": "^1.2.5",
+                "http-deceiver": "^1.2.7",
+                "safe-buffer": "^5.0.1",
+                "select-hose": "^2.0.0",
+                "spdy-transport": "^2.0.18"
+            }
+        },
+        "spdy-transport": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.1.tgz",
+            "integrity": "sha512-q7D8c148escoB3Z7ySCASadkegMmUZW8Wb/Q1u0/XBgDKMO880rLQDj8Twiew/tYi7ghemKUi/whSYOwE17f5Q==",
+            "dev": true,
+            "requires": {
+                "debug": "^2.6.8",
+                "detect-node": "^2.0.3",
+                "hpack.js": "^2.1.6",
+                "obuf": "^1.1.1",
+                "readable-stream": "^2.2.9",
+                "safe-buffer": "^5.0.1",
+                "wbuf": "^1.7.2"
+            }
+        },
+        "split": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+            "dev": true,
+            "requires": {
+                "through": "2"
+            }
+        },
+        "split-string": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+            "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "^3.0.0"
+            }
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "sshpk": {
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
+            "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+            "dev": true,
+            "requires": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
+            }
+        },
+        "ssri": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
+            "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.1.1"
+            }
+        },
+        "state-toggle": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.1.tgz",
+            "integrity": "sha512-Qe8QntFrrpWTnHwvwj2FZTgv+PKIsp0B9VxLzLLbSpPXWOgRgc5LVj/aTiSfK1RqIeF9jeC1UeOH8Q8y60A7og==",
+            "dev": true
+        },
+        "static-extend": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+            "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+            "dev": true,
+            "requires": {
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "statuses": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+            "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+            "dev": true
+        },
+        "stdout-stream": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
+            "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.1"
+            }
+        },
+        "stealthy-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+            "dev": true
+        },
+        "stream-browserify": {
+            "version": "2.0.1",
+            "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+            "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+            "dev": true,
+            "requires": {
+                "inherits": "~2.0.1",
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "stream-combiner": {
+            "version": "0.2.2",
+            "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+            "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+            "dev": true,
+            "requires": {
+                "duplexer": "~0.1.1",
+                "through": "~2.3.4"
+            }
+        },
+        "stream-each": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
+            "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "stream-shift": "^1.0.0"
+            }
+        },
+        "stream-http": {
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
+            "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+            "dev": true,
+            "requires": {
+                "builtin-status-codes": "^3.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.3.6",
+                "to-arraybuffer": "^1.0.0",
+                "xtend": "^4.0.0"
+            }
+        },
+        "stream-shift": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+            "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+            "dev": true
+        },
+        "strict-uri-encode": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+            "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+            "dev": true
+        },
+        "string-width": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "dev": true,
+            "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+            }
+        },
+        "string.prototype.trim": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+            "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.5.0",
+                "function-bind": "^1.0.2"
+            }
+        },
+        "string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "stringify-entities": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
+            "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
+            "dev": true,
+            "requires": {
+                "character-entities-html4": "^1.0.0",
+                "character-entities-legacy": "^1.0.0",
+                "is-alphanumerical": "^1.0.0",
+                "is-hexadecimal": "^1.0.0"
+            }
+        },
+        "stringify-object": {
+            "version": "2.4.0",
+            "resolved": "http://registry.npmjs.org/stringify-object/-/stringify-object-2.4.0.tgz",
+            "integrity": "sha1-xi0RAj6yH+LZsIe+A5om3zsioJ0=",
+            "dev": true,
+            "requires": {
+                "is-plain-obj": "^1.0.0",
+                "is-regexp": "^1.0.0"
+            }
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            }
+        },
+        "strip-bom": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+            "dev": true,
+            "requires": {
+                "is-utf8": "^0.2.0"
+            }
+        },
+        "strip-eof": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+            "dev": true
+        },
+        "strip-indent": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+            "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+            "dev": true,
+            "requires": {
+                "get-stdin": "^4.0.1"
+            }
+        },
+        "strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "dev": true
+        },
+        "style-loader": {
+            "version": "0.18.2",
+            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.18.2.tgz",
+            "integrity": "sha512-WPpJPZGUxWYHWIUMNNOYqql7zh85zGmr84FdTVWq52WTIkqlW9xSxD3QYWi/T31cqn9UNSsietVEgGn2aaSCzw==",
+            "dev": true,
+            "requires": {
+                "loader-utils": "^1.0.2",
+                "schema-utils": "^0.3.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "5.5.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+                    "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+                    "dev": true,
+                    "requires": {
+                        "co": "^4.6.0",
+                        "fast-deep-equal": "^1.0.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0"
+                    }
+                },
+                "fast-deep-equal": {
+                    "version": "1.1.0",
+                    "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+                    "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+                    "dev": true
+                },
+                "json-schema-traverse": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+                    "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+                    "dev": true
+                },
+                "schema-utils": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
+                    "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^5.0.0"
+                    }
+                }
+            }
+        },
+        "supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^3.0.0"
+            }
+        },
+        "svgo": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
+            "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
+            "dev": true,
+            "requires": {
+                "coa": "~1.0.1",
+                "colors": "~1.1.2",
+                "csso": "~2.3.1",
+                "js-yaml": "~3.7.0",
+                "mkdirp": "~0.5.1",
+                "sax": "~1.2.1",
+                "whet.extend": "~0.9.9"
+            }
+        },
+        "symbol-observable": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+            "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+            "dev": true
+        },
+        "symbol-tree": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+            "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+            "dev": true
+        },
+        "table": {
+            "version": "3.8.3",
+            "resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
+            "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+            "dev": true,
+            "requires": {
+                "ajv": "^4.7.0",
+                "ajv-keywords": "^1.0.0",
+                "chalk": "^1.1.1",
+                "lodash": "^4.0.0",
+                "slice-ansi": "0.0.4",
+                "string-width": "^2.0.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "4.11.8",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                    "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+                    "dev": true,
+                    "requires": {
+                        "co": "^4.6.0",
+                        "json-stable-stringify": "^1.0.1"
+                    }
+                },
+                "ajv-keywords": {
+                    "version": "1.5.1",
+                    "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+                    "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+                    "dev": true
+                },
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "tapable": {
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
+            "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
+            "dev": true
+        },
+        "tar": {
+            "version": "2.2.1",
+            "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+            "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+            "dev": true,
+            "requires": {
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
+            }
+        },
+        "term-size": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+            "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+            "dev": true,
+            "requires": {
+                "execa": "^0.7.0"
+            }
+        },
+        "text-encoding": {
+            "version": "0.6.4",
+            "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+            "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+            "dev": true
+        },
+        "text-table": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "through2": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "dev": true,
+            "requires": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
+            }
+        },
+        "thunky": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.3.tgz",
+            "integrity": "sha512-YwT8pjmNcAXBZqrubu22P4FYsh2D4dxRmnWBOL8Jk8bUcRUtc5326kx32tuTmFDAZtLOGEVNl8POAR8j896Iow==",
+            "dev": true
+        },
+        "time-stamp": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.2.0.tgz",
+            "integrity": "sha512-zxke8goJQpBeEgD82CXABeMh0LSJcj7CXEd0OHOg45HgcofF7pxNwZm9+RknpxpDhwN4gFpySkApKfFYfRQnUA==",
+            "dev": true
+        },
+        "timed-out": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+            "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+            "dev": true
+        },
+        "timers-browserify": {
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
+            "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
+            "dev": true,
+            "requires": {
+                "setimmediate": "^1.0.4"
+            }
+        },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dev": true,
+            "requires": {
+                "os-tmpdir": "~1.0.2"
+            }
+        },
+        "to-arraybuffer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+            "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+            "dev": true
+        },
+        "to-ast": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/to-ast/-/to-ast-1.0.0.tgz",
+            "integrity": "sha1-DEoxyMmO396arwGSx5S0yLEe4oc=",
+            "dev": true,
+            "requires": {
+                "ast-types": "^0.7.2",
+                "esprima": "^2.1.0"
+            },
+            "dependencies": {
+                "ast-types": {
+                    "version": "0.7.8",
+                    "resolved": "http://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
+                    "integrity": "sha1-kC0uDWDQcb3NRtwRXhgJ7RHBOKk=",
+                    "dev": true
+                }
+            }
+        },
+        "to-fast-properties": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+            "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+            "dev": true
+        },
+        "to-object-path": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+            "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "to-regex": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+            "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+            "dev": true,
+            "requires": {
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
+            }
+        },
+        "to-regex-range": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+            "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+            "dev": true,
+            "requires": {
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
+            }
+        },
+        "toposort": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
+            "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
+            "dev": true
+        },
+        "touch": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
+            "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
+            "dev": true,
+            "requires": {
+                "nopt": "~1.0.10"
+            },
+            "dependencies": {
+                "nopt": {
+                    "version": "1.0.10",
+                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+                    "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+                    "dev": true,
+                    "requires": {
+                        "abbrev": "1"
+                    }
+                }
+            }
+        },
+        "tough-cookie": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+            "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+            "dev": true,
+            "requires": {
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                    "dev": true
+                }
+            }
+        },
+        "tr46": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+            "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "traverse": {
+            "version": "0.6.6",
+            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+            "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+            "dev": true
+        },
+        "trim": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+            "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+            "dev": true
+        },
+        "trim-newlines": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+            "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+            "dev": true
+        },
+        "trim-right": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+            "dev": true
+        },
+        "trim-trailing-lines": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz",
+            "integrity": "sha512-bWLv9BbWbbd7mlqqs2oQYnLD/U/ZqeJeJwbO0FG2zA1aTq+HTvxfHNKFa/HGCVyJpDiioUYaBhfiT6rgk+l4mg==",
+            "dev": true
+        },
+        "trough": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.3.tgz",
+            "integrity": "sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==",
+            "dev": true
+        },
+        "true-case-path": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
+            "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.2"
+            }
+        },
+        "ts-loader": {
+            "version": "3.5.0",
+            "resolved": "http://registry.npmjs.org/ts-loader/-/ts-loader-3.5.0.tgz",
+            "integrity": "sha512-JTia3kObhTk36wPFgy0RnkZReiusYx7Le9IhcUWRrCTcFcr6Dy1zGsFd3x8DG4gevlbN65knI8W50FfoykXcng==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.3.0",
+                "enhanced-resolve": "^3.0.0",
+                "loader-utils": "^1.0.2",
+                "micromatch": "^3.1.4",
+                "semver": "^5.0.1"
+            }
+        },
+        "ts-node": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+            "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+            "dev": true,
+            "requires": {
+                "arrify": "^1.0.0",
+                "buffer-from": "^1.1.0",
+                "diff": "^3.1.0",
+                "make-error": "^1.1.1",
+                "minimist": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.5.6",
+                "yn": "^2.0.0"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
+            }
+        },
+        "tslib": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+            "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+            "dev": true
+        },
+        "tslint": {
+            "version": "5.11.0",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
+            "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+            "dev": true,
+            "requires": {
+                "babel-code-frame": "^6.22.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.3.0",
+                "commander": "^2.12.1",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "js-yaml": "^3.7.0",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.8.0",
+                "tsutils": "^2.27.2"
+            }
+        },
+        "tslint-react": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/tslint-react/-/tslint-react-3.6.0.tgz",
+            "integrity": "sha512-AIv1QcsSnj7e9pFir6cJ6vIncTqxfqeFF3Lzh8SuuBljueYzEAtByuB6zMaD27BL0xhMEqsZ9s5eHuCONydjBw==",
+            "dev": true,
+            "requires": {
+                "tsutils": "^2.13.1"
+            }
+        },
+        "tsutils": {
+            "version": "2.29.0",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+            "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.8.1"
+            }
+        },
+        "tty-browserify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+            "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+            "dev": true
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true
+        },
+        "type-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "~1.1.2"
+            }
+        },
+        "type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+            "dev": true
+        },
+        "type-is": {
+            "version": "1.6.16",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+            "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+            "dev": true,
+            "requires": {
+                "media-typer": "0.3.0",
+                "mime-types": "~2.1.18"
+            }
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
+        },
+        "typescript": {
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+            "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+            "dev": true
+        },
+        "uglify-js": {
+            "version": "3.4.9",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+            "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+            "dev": true,
+            "requires": {
+                "commander": "~2.17.1",
+                "source-map": "~0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "uglify-to-browserify": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+            "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+            "dev": true,
+            "optional": true
+        },
+        "uglifyjs-webpack-plugin": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.7.tgz",
+            "integrity": "sha512-1VicfKhCYHLS8m1DCApqBhoulnASsEoJ/BvpUpP4zoNAPpKzdH+ghk0olGJMmwX2/jprK2j3hAHdUbczBSy2FA==",
+            "dev": true,
+            "requires": {
+                "cacache": "^10.0.4",
+                "find-cache-dir": "^1.0.0",
+                "schema-utils": "^0.4.5",
+                "serialize-javascript": "^1.4.0",
+                "source-map": "^0.6.1",
+                "uglify-es": "^3.3.4",
+                "webpack-sources": "^1.1.0",
+                "worker-farm": "^1.5.2"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.13.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+                    "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "uglify-es": {
+                    "version": "3.3.9",
+                    "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+                    "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+                    "dev": true,
+                    "requires": {
+                        "commander": "~2.13.0",
+                        "source-map": "~0.6.1"
+                    }
+                }
+            }
+        },
+        "undefsafe": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.2.tgz",
+            "integrity": "sha1-Il9rngM3Zj4Njnz9aG/Cg2zKznY=",
+            "dev": true,
+            "requires": {
+                "debug": "^2.2.0"
+            }
+        },
+        "underscore": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+            "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
+            "dev": true
+        },
+        "unherit": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
+            "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "xtend": "^4.0.1"
+            }
+        },
+        "unicode-canonical-property-names-ecmascript": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+            "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+            "dev": true
+        },
+        "unicode-match-property-ecmascript": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+            "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+            "dev": true,
+            "requires": {
+                "unicode-canonical-property-names-ecmascript": "^1.0.4",
+                "unicode-property-aliases-ecmascript": "^1.0.4"
+            }
+        },
+        "unicode-match-property-value-ecmascript": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
+            "integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
+            "dev": true
+        },
+        "unicode-property-aliases-ecmascript": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
+            "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
+            "dev": true
+        },
+        "unified": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
+            "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
+            "dev": true,
+            "requires": {
+                "bail": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "trough": "^1.0.0",
+                "vfile": "^2.0.0",
+                "x-is-string": "^0.1.0"
+            }
+        },
+        "union-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+            "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+            "dev": true,
+            "requires": {
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                },
+                "set-value": {
+                    "version": "0.4.3",
+                    "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+                    "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.1",
+                        "to-object-path": "^0.3.0"
+                    }
+                }
+            }
+        },
+        "uniq": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+            "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+            "dev": true
+        },
+        "uniqs": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+            "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
+            "dev": true
+        },
+        "unique-filename": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+            "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+            "dev": true,
+            "requires": {
+                "unique-slug": "^2.0.0"
+            }
+        },
+        "unique-slug": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
+            "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
+            "dev": true,
+            "requires": {
+                "imurmurhash": "^0.1.4"
+            }
+        },
+        "unique-string": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+            "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+            "dev": true,
+            "requires": {
+                "crypto-random-string": "^1.0.0"
+            }
+        },
+        "unist-util-is": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz",
+            "integrity": "sha512-YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw==",
+            "dev": true
+        },
+        "unist-util-remove-position": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz",
+            "integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
+            "dev": true,
+            "requires": {
+                "unist-util-visit": "^1.1.0"
+            }
+        },
+        "unist-util-stringify-position": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+            "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
+            "dev": true
+        },
+        "unist-util-visit": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.0.tgz",
+            "integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
+            "dev": true,
+            "requires": {
+                "unist-util-visit-parents": "^2.0.0"
+            }
+        },
+        "unist-util-visit-parents": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz",
+            "integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
+            "dev": true,
+            "requires": {
+                "unist-util-is": "^2.1.2"
+            }
+        },
+        "universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true
+        },
+        "unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "dev": true
+        },
+        "unquote": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+            "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
+            "dev": true
+        },
+        "unset-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+            "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+            "dev": true,
+            "requires": {
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
+            },
+            "dependencies": {
+                "has-value": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+                    "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+                    "dev": true,
+                    "requires": {
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "isobject": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                            "dev": true,
+                            "requires": {
+                                "isarray": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "has-values": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+                    "dev": true
+                }
+            }
+        },
+        "unzip-response": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+            "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+            "dev": true
+        },
+        "upath": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
+            "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+            "dev": true
+        },
+        "update-notifier": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+            "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+            "dev": true,
+            "requires": {
+                "boxen": "^1.2.1",
+                "chalk": "^2.0.1",
+                "configstore": "^3.0.0",
+                "import-lazy": "^2.1.0",
+                "is-ci": "^1.0.10",
+                "is-installed-globally": "^0.1.0",
+                "is-npm": "^1.0.0",
+                "latest-version": "^3.0.0",
+                "semver-diff": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
+            }
+        },
+        "upper-case": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+            "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+            "dev": true
+        },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "urix": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+            "dev": true
+        },
+        "url": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+            "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+            "dev": true,
+            "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+                    "dev": true
+                }
+            }
+        },
+        "url-parse": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+            "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
+            "dev": true,
+            "requires": {
+                "querystringify": "^2.0.0",
+                "requires-port": "^1.0.0"
+            }
+        },
+        "url-parse-lax": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+            "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+            "dev": true,
+            "requires": {
+                "prepend-http": "^1.0.1"
+            }
+        },
+        "use": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+            "dev": true
+        },
+        "user-home": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+            "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+            "dev": true,
+            "requires": {
+                "os-homedir": "^1.0.0"
+            }
+        },
+        "util": {
+            "version": "0.10.4",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+            "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3"
+            }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "utila": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
+            "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
+            "dev": true
+        },
+        "utils-merge": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+            "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+            "dev": true
+        },
+        "uuid": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+            "dev": true
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
+            "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+            "dev": true
+        },
+        "vendors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.2.tgz",
+            "integrity": "sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ==",
+            "dev": true
+        },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            }
+        },
+        "vfile": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
+            "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+            "dev": true,
+            "requires": {
+                "is-buffer": "^1.1.4",
+                "replace-ext": "1.0.0",
+                "unist-util-stringify-position": "^1.0.0",
+                "vfile-message": "^1.0.0"
+            }
+        },
+        "vfile-location": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.4.tgz",
+            "integrity": "sha512-KRL5uXQPoUKu+NGvQVL4XLORw45W62v4U4gxJ3vRlDfI9QsT4ZN1PNXn/zQpKUulqGDpYuT0XDfp5q9O87/y/w==",
+            "dev": true
+        },
+        "vfile-message": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.2.tgz",
+            "integrity": "sha512-dNdEXHfPCvzyOlEaaQ+DcXpcxEz+pFvdrebKLiAMjobjaBC2bMeWoHOKPwJ+I8A4jQOEUDH7uoVcLWDLF1qhVQ==",
+            "dev": true,
+            "requires": {
+                "unist-util-stringify-position": "^1.1.1"
+            }
+        },
+        "vlq": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.0.tgz",
+            "integrity": "sha512-o3WmXySo+oI5thgqr7Qy8uBkT/v9Zr+sRyrh1lr8aWPUkgDWdWt4Nae2WKBrLsocgE8BuWWD0jLc+VW8LeU+2g==",
+            "dev": true
+        },
+        "vm-browserify": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+            "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+            "dev": true,
+            "requires": {
+                "indexof": "0.0.1"
+            }
+        },
+        "w3c-hr-time": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+            "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+            "dev": true,
+            "requires": {
+                "browser-process-hrtime": "^0.1.2"
+            }
+        },
+        "warning": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+            "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.0.0"
+            }
+        },
+        "watchpack": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
+            "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
+            "dev": true,
+            "requires": {
+                "chokidar": "^2.0.2",
+                "graceful-fs": "^4.1.2",
+                "neo-async": "^2.5.0"
+            }
+        },
+        "wbuf": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+            "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+            "dev": true,
+            "requires": {
+                "minimalistic-assert": "^1.0.0"
+            }
+        },
+        "wcwidth": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+            "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+            "dev": true,
+            "requires": {
+                "defaults": "^1.0.3"
+            }
+        },
+        "webidl-conversions": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+            "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+            "dev": true
+        },
+        "webpack": {
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.12.0.tgz",
+            "integrity": "sha512-Sw7MdIIOv/nkzPzee4o0EdvCuPmxT98+vVpIvwtcwcF1Q4SDSNp92vwcKc4REe7NItH9f1S4ra9FuQ7yuYZ8bQ==",
+            "dev": true,
+            "requires": {
+                "acorn": "^5.0.0",
+                "acorn-dynamic-import": "^2.0.0",
+                "ajv": "^6.1.0",
+                "ajv-keywords": "^3.1.0",
+                "async": "^2.1.2",
+                "enhanced-resolve": "^3.4.0",
+                "escope": "^3.6.0",
+                "interpret": "^1.0.0",
+                "json-loader": "^0.5.4",
+                "json5": "^0.5.1",
+                "loader-runner": "^2.3.0",
+                "loader-utils": "^1.1.0",
+                "memory-fs": "~0.4.1",
+                "mkdirp": "~0.5.0",
+                "node-libs-browser": "^2.0.0",
+                "source-map": "^0.5.3",
+                "supports-color": "^4.2.1",
+                "tapable": "^0.2.7",
+                "uglifyjs-webpack-plugin": "^0.4.6",
+                "watchpack": "^1.4.0",
+                "webpack-sources": "^1.0.1",
+                "yargs": "^8.0.2"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.7.3",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+                    "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+                    "dev": true
+                },
+                "acorn-dynamic-import": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
+                    "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
+                    "dev": true,
+                    "requires": {
+                        "acorn": "^4.0.3"
+                    },
+                    "dependencies": {
+                        "acorn": {
+                            "version": "4.0.13",
+                            "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+                            "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+                            "dev": true
+                        }
+                    }
+                },
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "camelcase": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                    "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                    "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                    "dev": true,
+                    "requires": {
+                        "center-align": "^0.1.1",
+                        "right-align": "^0.1.1",
+                        "wordwrap": "0.0.2"
+                    }
+                },
+                "enhanced-resolve": {
+                    "version": "3.4.1",
+                    "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+                    "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "memory-fs": "^0.4.0",
+                        "object-assign": "^4.0.1",
+                        "tapable": "^0.2.7"
+                    }
+                },
+                "has-flag": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+                    "dev": true
+                },
+                "load-json-file": {
+                    "version": "2.0.0",
+                    "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+                    "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "strip-bom": "^3.0.0"
+                    }
+                },
+                "os-locale": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+                    "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+                    "dev": true,
+                    "requires": {
+                        "execa": "^0.7.0",
+                        "lcid": "^1.0.0",
+                        "mem": "^1.1.0"
+                    }
+                },
+                "path-type": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+                    "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^2.0.0"
+                    }
+                },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+                    "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "^2.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^2.0.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+                    "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^2.0.0",
+                        "read-pkg": "^2.0.0"
+                    }
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "is-fullwidth-code-point": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                            "dev": true
+                        },
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "4.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^2.0.0"
+                    }
+                },
+                "uglify-js": {
+                    "version": "2.8.29",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+                    "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+                    "dev": true,
+                    "requires": {
+                        "source-map": "~0.5.1",
+                        "uglify-to-browserify": "~1.0.0",
+                        "yargs": "~3.10.0"
+                    },
+                    "dependencies": {
+                        "yargs": {
+                            "version": "3.10.0",
+                            "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                            "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+                            "dev": true,
+                            "requires": {
+                                "camelcase": "^1.0.2",
+                                "cliui": "^2.1.0",
+                                "decamelize": "^1.0.0",
+                                "window-size": "0.1.0"
+                            }
+                        }
+                    }
+                },
+                "uglifyjs-webpack-plugin": {
+                    "version": "0.4.6",
+                    "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
+                    "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
+                    "dev": true,
+                    "requires": {
+                        "source-map": "^0.5.6",
+                        "uglify-js": "^2.8.29",
+                        "webpack-sources": "^1.0.1"
+                    }
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+                    "dev": true
+                },
+                "wordwrap": {
+                    "version": "0.0.2",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                    "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "8.0.2",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+                    "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^4.1.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^2.0.0",
+                        "read-pkg-up": "^2.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^7.0.0"
+                    },
+                    "dependencies": {
+                        "camelcase": {
+                            "version": "4.1.0",
+                            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                            "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                            "dev": true
+                        },
+                        "cliui": {
+                            "version": "3.2.0",
+                            "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                            "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                            "dev": true,
+                            "requires": {
+                                "string-width": "^1.0.1",
+                                "strip-ansi": "^3.0.1",
+                                "wrap-ansi": "^2.0.0"
+                            },
+                            "dependencies": {
+                                "string-width": {
+                                    "version": "1.0.2",
+                                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                                    "dev": true,
+                                    "requires": {
+                                        "code-point-at": "^1.0.0",
+                                        "is-fullwidth-code-point": "^1.0.0",
+                                        "strip-ansi": "^3.0.0"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "yargs-parser": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+                    "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^4.1.0"
+                    },
+                    "dependencies": {
+                        "camelcase": {
+                            "version": "4.1.0",
+                            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                            "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                            "dev": true
+                        }
+                    }
+                }
+            }
+        },
+        "webpack-dev-middleware": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
+            "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
+            "dev": true,
+            "requires": {
+                "memory-fs": "~0.4.1",
+                "mime": "^1.5.0",
+                "path-is-absolute": "^1.0.0",
+                "range-parser": "^1.0.3",
+                "time-stamp": "^2.0.0"
+            },
+            "dependencies": {
+                "mime": {
+                    "version": "1.6.0",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+                    "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+                    "dev": true
+                }
+            }
+        },
+        "webpack-dev-server": {
+            "version": "2.11.3",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.3.tgz",
+            "integrity": "sha512-Qz22YEFhWx+M2vvJ+rQppRv39JA0h5NNbOOdODApdX6iZ52Diz7vTPXjF7kJlfn+Uc24Qr48I3SZ9yncQwRycg==",
+            "dev": true,
+            "requires": {
+                "ansi-html": "0.0.7",
+                "array-includes": "^3.0.3",
+                "bonjour": "^3.5.0",
+                "chokidar": "^2.0.0",
+                "compression": "^1.5.2",
+                "connect-history-api-fallback": "^1.3.0",
+                "debug": "^3.1.0",
+                "del": "^3.0.0",
+                "express": "^4.16.2",
+                "html-entities": "^1.2.0",
+                "http-proxy-middleware": "~0.17.4",
+                "import-local": "^1.0.0",
+                "internal-ip": "1.2.0",
+                "ip": "^1.1.5",
+                "killable": "^1.0.0",
+                "loglevel": "^1.4.1",
+                "opn": "^5.1.0",
+                "portfinder": "^1.0.9",
+                "selfsigned": "^1.9.1",
+                "serve-index": "^1.7.2",
+                "sockjs": "0.3.19",
+                "sockjs-client": "1.1.5",
+                "spdy": "^3.4.1",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^5.1.0",
+                "webpack-dev-middleware": "1.12.2",
+                "yargs": "6.6.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "6.6.0",
+                    "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+                    "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^4.2.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "4.2.1",
+                    "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+                    "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "webpack-merge": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.1.4.tgz",
+            "integrity": "sha512-TmSe1HZKeOPey3oy1Ov2iS3guIZjWvMT2BBJDzzT5jScHTjVC3mpjJofgueEzaEd6ibhxRDD6MIblDr8tzh8iQ==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.5"
+            }
+        },
+        "webpack-sources": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
+            "integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
+            "dev": true,
+            "requires": {
+                "source-list-map": "^2.0.0",
+                "source-map": "~0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "websocket-driver": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+            "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+            "dev": true,
+            "requires": {
+                "http-parser-js": ">=0.4.0",
+                "websocket-extensions": ">=0.1.1"
+            }
+        },
+        "websocket-extensions": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+            "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+            "dev": true
+        },
+        "whatwg-encoding": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+            "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+            "dev": true,
+            "requires": {
+                "iconv-lite": "0.4.24"
+            }
+        },
+        "whatwg-mimetype": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.2.0.tgz",
+            "integrity": "sha512-5YSO1nMd5D1hY3WzAQV3PzZL83W3YeyR1yW9PcH26Weh1t+Vzh9B6XkDh7aXm83HBZ4nSMvkjvN2H2ySWIvBgw==",
+            "dev": true
+        },
+        "whatwg-url": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+            "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+            "dev": true,
+            "requires": {
+                "lodash.sortby": "^4.7.0",
+                "tr46": "^1.0.1",
+                "webidl-conversions": "^4.0.2"
+            }
+        },
+        "whet.extend": {
+            "version": "0.9.9",
+            "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+            "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
+            "dev": true
+        },
+        "which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
+        "which-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+            "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+            "dev": true
+        },
+        "wide-align": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+            "dev": true,
+            "requires": {
+                "string-width": "^1.0.2 || 2"
+            }
+        },
+        "widest-line": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+            "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+            "dev": true,
+            "requires": {
+                "string-width": "^2.1.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "window-size": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+            "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+            "dev": true
+        },
+        "wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+            "dev": true
+        },
+        "worker-farm": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
+            "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+            "dev": true,
+            "requires": {
+                "errno": "~0.1.7"
+            }
+        },
+        "wrap-ansi": {
+            "version": "2.1.0",
+            "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "dev": true,
+            "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "write": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+            "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+            "dev": true,
+            "requires": {
+                "mkdirp": "^0.5.1"
+            }
+        },
+        "write-file-atomic": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+            "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
+            }
+        },
+        "ws": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
+            "integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
+            "dev": true,
+            "requires": {
+                "async-limiter": "~1.0.0"
+            }
+        },
+        "x-is-string": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+            "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
+            "dev": true
+        },
+        "xdg-basedir": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+            "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+            "dev": true
+        },
+        "xml-name-validator": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+            "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+            "dev": true
+        },
+        "xmlchars": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-1.3.1.tgz",
+            "integrity": "sha512-tGkGJkN8XqCod7OT+EvGYK5Z4SfDQGD30zAa58OcnAa0RRWgzUEK72tkXhsX1FZd+rgnhRxFtmO+ihkp8LHSkw==",
+            "dev": true
+        },
+        "xtend": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+            "dev": true
+        },
+        "y18n": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+            "dev": true
+        },
+        "yallist": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+            "dev": true
+        },
+        "yargs": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+            "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+            "dev": true,
+            "requires": {
+                "camelcase": "^3.0.0",
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^1.4.0",
+                "read-pkg-up": "^1.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^1.0.2",
+                "which-module": "^1.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^5.0.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+                    "dev": true
+                }
+            }
+        },
+        "yargs-parser": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+            "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+            "dev": true,
+            "requires": {
+                "camelcase": "^3.0.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+                    "dev": true
+                }
+            }
+        },
+        "yn": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+            "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+            "dev": true
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "4.0.9",
+    "version": "5.0.0-alpha.1",
     "description": "Azure IoT Fluent React Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
@@ -12,7 +12,8 @@
         "sasslint": "sass-lint -c .sass-lint.yml 'lib/**/*.scss' -v -q",
         "docs": "styleguidist server",
         "docs:build": "styleguidist build",
-        "prepublish": "npm run tslint && npm run test && npm run build"
+        "postinstall": "node ./lib/scripts/postinstall.js",
+        "prepublishOnly": "npm run tslint && npm run test && npm run build"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "5.0.0-alpha.1",
+    "version": "5.0.0-alpha.2",
     "description": "Azure IoT Fluent React Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "5.0.0-alpha.2",
-    "description": "Azure IoT Fluent React Controls",
+    "version": "5.0.0",
+    "description": "Azure IoT UX Fluent Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "scripts": {
@@ -17,9 +17,11 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/Azure/iot-ux-fluent-controls/issues"
+        "url": "https://github.com/Azure/iot-ux-fluent-controls.git"
     },
-    "author": "",
+    "homepage": "https://github.com/Azure/iot-ux-fluent-controls#readme",
+    "bugs": "https://github.com/Azure/iot-ux-fluent-controls/issues",
+    "author": "Azure IoT",
     "license": "MIT",
     "engines": {
         "node": ">=8"

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -1,0 +1,2 @@
+// finally, import the default colors:
+@import "~@microsoft/azure-iot-ux-fluent-css/src/colors";

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -1,2 +1,22 @@
-// finally, import the default colors:
+// WARNING: DO NOT MOVE THIS FILE!
+// The @microsoft/azure-iot-ux-fluent-controls library requires a _colors.scss to
+// exist at the <project root>/src/styles/. This allows each project to override or
+// extend the colors specified in @microsoft/azure-iot-ux-fluent-css and have them
+// apply to the controls seamlessly. The following code demonstrates this pattern:
+
+    // // first import the color palette:
+    // @import "~@microsoft/azure-iot-ux-fluent-css/src/color.palette";
+    // // specify overrides/extensions for the themes:
+    // $theme-dark: (
+    //     color-bg-header: $color-grey-1200,
+    //     color-bg-content: #3d4147,
+    //     color-text-header: $color-white,
+    // );
+
+    // $theme-light: (
+    //     color-bg-header: $color-grey-800,
+    //     color-text-header: $color-white,
+    // );
+
+// as a final step, import the default colors (this will preserve any overrides specified above):
 @import "~@microsoft/azure-iot-ux-fluent-css/src/colors";

--- a/webpack.styleguide.js
+++ b/webpack.styleguide.js
@@ -45,14 +45,6 @@ module.exports = {
           },
           {
             loader: 'sass-loader',
-            options: {
-              includePaths: [
-                path.resolve(
-                  __dirname,
-                  'node_modules/@microsoft/azure-iot-ux-fluent-css/src/'
-                ),
-              ],
-            },
           },
         ],
       },


### PR DESCRIPTION
The controls library previously depended on a global `colors` import, which would be resolved to an actual file through a webpack IncludePath declaration. This pattern meant we could not use the library with create-react-app unless we ejected, which is not optimal.

To avoid this, this PR changes the convention to depend on a `./src/styles/_colors.scss` file existing at the project root instead. This file is created as a postinstall step when the controls library is installed.