### PR TITLE
Remove high-vulnerability packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -415,48 +415,6 @@
             "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
             "dev": true
         },
-        "ansi-align": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-            "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-            "dev": true,
-            "requires": {
-                "string-width": "^2.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^3.0.0"
-                    }
-                }
-            }
-        },
         "ansi-escapes": {
             "version": "3.1.0",
             "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
@@ -1528,60 +1486,6 @@
             "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
             "dev": true
         },
-        "boxen": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-            "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
-            "dev": true,
-            "requires": {
-                "ansi-align": "^2.0.0",
-                "camelcase": "^4.0.0",
-                "chalk": "^2.0.1",
-                "cli-boxes": "^1.0.0",
-                "string-width": "^2.0.0",
-                "term-size": "^1.2.0",
-                "widest-line": "^2.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
-                "camelcase": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^3.0.0"
-                    }
-                }
-            }
-        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1938,12 +1842,6 @@
             "integrity": "sha512-uQ/L28utpeTyjvy7PQtGamXtfLYJrnTD3YewssFIEUfZGNRZgY8M2ttKUbTNmw5hjGfcd/NdnXXD1NBMB4P4Uw==",
             "dev": true
         },
-        "capture-stack-trace": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
-            "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
-            "dev": true
-        },
         "caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -2078,12 +1976,6 @@
             "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
             "dev": true
         },
-        "ci-info": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-            "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
-            "dev": true
-        },
         "cipher-base": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -2190,12 +2082,6 @@
             "requires": {
                 "rimraf": "^2.6.1"
             }
-        },
-        "cli-boxes": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-            "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
-            "dev": true
         },
         "cli-cursor": {
             "version": "2.1.0",
@@ -2449,20 +2335,6 @@
                 "typedarray": "^0.0.6"
             }
         },
-        "configstore": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
-            "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
-            "dev": true,
-            "requires": {
-                "dot-prop": "^4.1.0",
-                "graceful-fs": "^4.1.2",
-                "make-dir": "^1.0.0",
-                "unique-string": "^1.0.0",
-                "write-file-atomic": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
-            }
-        },
         "connect-history-api-fallback": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
@@ -2595,15 +2467,6 @@
                 "elliptic": "^6.0.0"
             }
         },
-        "create-error-class": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-            "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-            "dev": true,
-            "requires": {
-                "capture-stack-trace": "^1.0.0"
-            }
-        },
         "create-hash": {
             "version": "1.2.0",
             "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -2659,12 +2522,6 @@
                 "randombytes": "^2.0.0",
                 "randomfill": "^1.0.3"
             }
-        },
-        "crypto-random-string": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-            "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
-            "dev": true
         },
         "css-color-names": {
             "version": "0.0.4",
@@ -2903,12 +2760,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
             "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-            "dev": true
-        },
-        "deep-extend": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
             "dev": true
         },
         "deep-is": {
@@ -3229,25 +3080,10 @@
                 "domelementtype": "1"
             }
         },
-        "dot-prop": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-            "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-            "dev": true,
-            "requires": {
-                "is-obj": "^1.0.0"
-            }
-        },
         "duplexer": {
             "version": "0.1.1",
             "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
             "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-            "dev": true
-        },
-        "duplexer3": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
             "dev": true
         },
         "duplexify": {
@@ -3820,22 +3656,6 @@
                 "es5-ext": "~0.10.14"
             }
         },
-        "event-stream": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
-            "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
-            "dev": true,
-            "requires": {
-                "duplexer": "^0.1.1",
-                "flatmap-stream": "^0.1.0",
-                "from": "^0.1.7",
-                "map-stream": "0.0.7",
-                "pause-stream": "^0.0.11",
-                "split": "^1.0.1",
-                "stream-combiner": "^0.2.2",
-                "through": "^2.3.8"
-            }
-        },
         "eventemitter3": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
@@ -4309,12 +4129,6 @@
                 "write": "^0.2.1"
             }
         },
-        "flatmap-stream": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.2.tgz",
-            "integrity": "sha512-ucyr6WkLXjyMuHPtOUq4l+nSAxgWi7v4QO508eQ9resnGj+lSup26oIsUI5aH8k4Qfpjsxa8dDf9UCKkS2KHzQ==",
-            "dev": true
-        },
         "flatten": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
@@ -4402,12 +4216,6 @@
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
             "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-            "dev": true
-        },
-        "from": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-            "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
             "dev": true
         },
         "from2": {
@@ -5200,15 +5008,6 @@
                 "process": "~0.5.1"
             }
         },
-        "global-dirs": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-            "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-            "dev": true,
-            "requires": {
-                "ini": "^1.3.4"
-            }
-        },
         "global-modules": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
@@ -5288,25 +5087,6 @@
                     "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
                     "dev": true
                 }
-            }
-        },
-        "got": {
-            "version": "6.7.1",
-            "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
-            "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-            "dev": true,
-            "requires": {
-                "create-error-class": "^3.0.0",
-                "duplexer3": "^0.1.4",
-                "get-stream": "^3.0.0",
-                "is-redirect": "^1.0.0",
-                "is-retry-allowed": "^1.0.0",
-                "is-stream": "^1.0.0",
-                "lowercase-keys": "^1.0.0",
-                "safe-buffer": "^5.0.1",
-                "timed-out": "^4.0.0",
-                "unzip-response": "^2.0.1",
-                "url-parse-lax": "^1.0.0"
             }
         },
         "graceful-fs": {
@@ -5853,22 +5633,10 @@
             "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
             "dev": true
         },
-        "ignore-by-default": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-            "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
-            "dev": true
-        },
         "ignore-styles": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ignore-styles/-/ignore-styles-5.0.1.tgz",
             "integrity": "sha1-tJ7yJ0va/NikiAqWa/440aC/RnE=",
-            "dev": true
-        },
-        "import-lazy": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-            "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
             "dev": true
         },
         "import-local": {
@@ -6123,15 +5891,6 @@
             "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
             "dev": true
         },
-        "is-ci": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-            "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
-            "dev": true,
-            "requires": {
-                "ci-info": "^1.5.0"
-            }
-        },
         "is-data-descriptor": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -6255,16 +6014,6 @@
             "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU=",
             "dev": true
         },
-        "is-installed-globally": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-            "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-            "dev": true,
-            "requires": {
-                "global-dirs": "^0.1.0",
-                "is-path-inside": "^1.0.0"
-            }
-        },
         "is-my-ip-valid": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
@@ -6283,12 +6032,6 @@
                 "jsonpointer": "^4.0.0",
                 "xtend": "^4.0.0"
             }
-        },
-        "is-npm": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-            "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
-            "dev": true
         },
         "is-number": {
             "version": "3.0.0",
@@ -6385,12 +6128,6 @@
             "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
             "dev": true
         },
-        "is-redirect": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-            "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-            "dev": true
-        },
         "is-regex": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
@@ -6410,12 +6147,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
             "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-            "dev": true
-        },
-        "is-retry-allowed": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-            "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
             "dev": true
         },
         "is-root": {
@@ -6789,15 +6520,6 @@
             "integrity": "sha512-QMQcnKAiQccfQTqtBh/qwquGZ2XK/DXND1jrcN9M8gMMy99Gwla7GQjndVUsEqIaRyP6bsFRuhwRj5poafBGJQ==",
             "dev": true
         },
-        "latest-version": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-            "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-            "dev": true,
-            "requires": {
-                "package-json": "^4.0.0"
-            }
-        },
         "lazy-cache": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
@@ -7101,12 +6823,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
             "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-            "dev": true
-        },
-        "map-stream": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-            "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
             "dev": true
         },
         "map-visit": {
@@ -7762,41 +7478,6 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                     "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                    "dev": true
-                }
-            }
-        },
-        "nodemon": {
-            "version": "1.18.6",
-            "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.6.tgz",
-            "integrity": "sha512-4pHQNYEZun+IkIC2jCaXEhkZnfA7rQe73i8RkdRyDJls/K+WxR7IpI5uNUsAvQ0zWvYcCDNGD+XVtw2ZG86/uQ==",
-            "dev": true,
-            "requires": {
-                "chokidar": "^2.0.4",
-                "debug": "^3.1.0",
-                "ignore-by-default": "^1.0.1",
-                "minimatch": "^3.0.4",
-                "pstree.remy": "^1.1.0",
-                "semver": "^5.5.0",
-                "supports-color": "^5.2.0",
-                "touch": "^3.1.0",
-                "undefsafe": "^2.0.2",
-                "update-notifier": "^2.3.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "3.2.6",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
                     "dev": true
                 }
             }
@@ -9390,18 +9071,6 @@
             "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
             "dev": true
         },
-        "package-json": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-            "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-            "dev": true,
-            "requires": {
-                "got": "^6.7.1",
-                "registry-auth-token": "^3.0.1",
-                "registry-url": "^3.0.3",
-                "semver": "^5.1.0"
-            }
-        },
         "pako": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
@@ -9592,15 +9261,6 @@
             "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
             "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
             "dev": true
-        },
-        "pause-stream": {
-            "version": "0.0.11",
-            "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-            "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-            "dev": true,
-            "requires": {
-                "through": "~2.3"
-            }
         },
         "pbkdf2": {
             "version": "3.0.17",
@@ -10232,15 +9892,6 @@
             "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
             "dev": true
         },
-        "ps-tree": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
-            "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
-            "dev": true,
-            "requires": {
-                "event-stream": "~3.3.0"
-            }
-        },
         "pseudomap": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -10252,15 +9903,6 @@
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
             "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
             "dev": true
-        },
-        "pstree.remy": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.0.tgz",
-            "integrity": "sha512-q5I5vLRMVtdWa8n/3UEzZX7Lfghzrg9eG2IKk2ENLSofKRCXVqMvMUHxCKgXNaqH/8ebhBxrqftHWnyTFweJ5Q==",
-            "dev": true,
-            "requires": {
-                "ps-tree": "^1.1.0"
-            }
         },
         "public-encrypt": {
             "version": "4.0.3",
@@ -10456,26 +10098,6 @@
                     "requires": {
                         "safer-buffer": ">= 2.1.2 < 3"
                     }
-                }
-            }
-        },
-        "rc": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "dev": true,
-            "requires": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
                 }
             }
         },
@@ -11045,25 +10667,6 @@
                 "regjsparser": "^0.1.4"
             }
         },
-        "registry-auth-token": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
-            "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
-            "dev": true,
-            "requires": {
-                "rc": "^1.1.6",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "registry-url": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-            "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-            "dev": true,
-            "requires": {
-                "rc": "^1.0.1"
-            }
-        },
         "regjsgen": {
             "version": "0.2.0",
             "resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
@@ -11607,15 +11210,6 @@
             "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
             "dev": true
         },
-        "semver-diff": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-            "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-            "dev": true,
-            "requires": {
-                "semver": "^5.0.3"
-            }
-        },
         "send": {
             "version": "0.16.2",
             "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
@@ -12106,15 +11700,6 @@
                 "wbuf": "^1.7.2"
             }
         },
-        "split": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-            "dev": true,
-            "requires": {
-                "through": "2"
-            }
-        },
         "split-string": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -12212,16 +11797,6 @@
             "requires": {
                 "inherits": "~2.0.1",
                 "readable-stream": "^2.0.2"
-            }
-        },
-        "stream-combiner": {
-            "version": "0.2.2",
-            "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-            "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-            "dev": true,
-            "requires": {
-                "duplexer": "~0.1.1",
-                "through": "~2.3.4"
             }
         },
         "stream-each": {
@@ -12344,12 +11919,6 @@
             "requires": {
                 "get-stdin": "^4.0.1"
             }
-        },
-        "strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-            "dev": true
         },
         "style-loader": {
             "version": "0.18.2",
@@ -12539,15 +12108,6 @@
                 "inherits": "2"
             }
         },
-        "term-size": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-            "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-            "dev": true,
-            "requires": {
-                "execa": "^0.7.0"
-            }
-        },
         "text-encoding": {
             "version": "0.6.4",
             "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
@@ -12586,12 +12146,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.2.0.tgz",
             "integrity": "sha512-zxke8goJQpBeEgD82CXABeMh0LSJcj7CXEd0OHOg45HgcofF7pxNwZm9+RknpxpDhwN4gFpySkApKfFYfRQnUA==",
-            "dev": true
-        },
-        "timed-out": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-            "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
             "dev": true
         },
         "timers-browserify": {
@@ -12689,26 +12243,6 @@
             "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
             "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
             "dev": true
-        },
-        "touch": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
-            "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
-            "dev": true,
-            "requires": {
-                "nopt": "~1.0.10"
-            },
-            "dependencies": {
-                "nopt": {
-                    "version": "1.0.10",
-                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-                    "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-                    "dev": true,
-                    "requires": {
-                        "abbrev": "1"
-                    }
-                }
-            }
         },
         "tough-cookie": {
             "version": "2.4.3",
@@ -12986,15 +12520,6 @@
                 }
             }
         },
-        "undefsafe": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.2.tgz",
-            "integrity": "sha1-Il9rngM3Zj4Njnz9aG/Cg2zKznY=",
-            "dev": true,
-            "requires": {
-                "debug": "^2.2.0"
-            }
-        },
         "underscore": {
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
@@ -13118,15 +12643,6 @@
                 "imurmurhash": "^0.1.4"
             }
         },
-        "unique-string": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-            "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-            "dev": true,
-            "requires": {
-                "crypto-random-string": "^1.0.0"
-            }
-        },
         "unist-util-is": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz",
@@ -13224,35 +12740,11 @@
                 }
             }
         },
-        "unzip-response": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-            "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-            "dev": true
-        },
         "upath": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
             "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
             "dev": true
-        },
-        "update-notifier": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
-            "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
-            "dev": true,
-            "requires": {
-                "boxen": "^1.2.1",
-                "chalk": "^2.0.1",
-                "configstore": "^3.0.0",
-                "import-lazy": "^2.1.0",
-                "is-ci": "^1.0.10",
-                "is-installed-globally": "^0.1.0",
-                "is-npm": "^1.0.0",
-                "latest-version": "^3.0.0",
-                "semver-diff": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
-            }
         },
         "upper-case": {
             "version": "1.1.3",
@@ -13301,15 +12793,6 @@
             "requires": {
                 "querystringify": "^2.0.0",
                 "requires-port": "^1.0.0"
-            }
-        },
-        "url-parse-lax": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-            "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-            "dev": true,
-            "requires": {
-                "prepend-http": "^1.0.1"
             }
         },
         "use": {
@@ -14011,48 +13494,6 @@
                 "string-width": "^1.0.2 || 2"
             }
         },
-        "widest-line": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-            "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
-            "dev": true,
-            "requires": {
-                "string-width": "^2.1.1"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^3.0.0"
-                    }
-                }
-            }
-        },
         "window-size": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
@@ -14099,17 +13540,6 @@
                 "mkdirp": "^0.5.1"
             }
         },
-        "write-file-atomic": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-            "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "^4.1.11",
-                "imurmurhash": "^0.1.4",
-                "signal-exit": "^3.0.2"
-            }
-        },
         "ws": {
             "version": "6.1.2",
             "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
@@ -14123,12 +13553,6 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
             "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
-            "dev": true
-        },
-        "xdg-basedir": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-            "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
             "dev": true
         },
         "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
         "json-loader": "^0.5.7",
         "mocha": "^5.2.0",
         "node-sass": "^4.8.3",
-        "nodemon": "^1.11.0",
         "nyc": "^13.1.0",
         "phantomjs-polyfill-object-assign": "0.0.2",
         "prop-types": "^15.6.1",
@@ -76,8 +75,7 @@
         "tslint": "^5.7.0",
         "tslint-react": "^3.2.0",
         "typescript": "^2.9.0",
-        "webpack": "^3.8.1",
-        "webpack-dev-server": "^2.9.4"
+        "webpack": "^3.8.1"
     },
     "peerDependencies": {
         "@microsoft/azure-iot-ux-fluent-css": "^4.0.0",


### PR DESCRIPTION
Remove nodemon and webpack-dev-server from package.json - they're not being used and are showing up in the npm audit.

We still have one high vulnerability coming from react-styleguidist > webpack-dev-server, but that requires updating to a new major version of styleguidist/webpack so leaving that for a different PR.