### PR TITLE
Fix accessibility issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v5.2.2
+## Fixed
+- BUG 3217787: [Form Field] If the user tabs out of a field when the tooltip button is open (Alt+F1), close the tooltip.
+- BUG 2383275: [Management List] Narrator should not read non-interactive column headers as Buttons.
+
 ## v5.2.1
 ## Changed
 - Update font url

--- a/lib/components/Field/FormField.spec.tsx
+++ b/lib/components/Field/FormField.spec.tsx
@@ -42,6 +42,14 @@ describe('Form Field Component', () => {
         expect(wrapper.instance().state.tooltipVisible).to.equal(false);
     });
 
+    it('should untoggle tool tip when alt + f1 is pressed and then tab is pressed', () => {
+        expect(wrapper.instance().state.tooltipVisible).to.equal(false);
+        wrapper.find('#test-field').simulate('keyDown', { keyCode: keyCode.f1, altKey: true });
+        expect(wrapper.instance().state.tooltipVisible).to.equal(true);
+        wrapper.find('#test-field').simulate('keyDown', { keyCode: keyCode.tab });
+        expect(wrapper.instance().state.tooltipVisible).to.equal(false);
+    });
+
     it('should leave tooltip toggled when any key other than escape is pressed', () => {
         expect(wrapper.instance().state.tooltipVisible).to.equal(false);
         wrapper.find('#test-field').simulate('keyDown', { keyCode: keyCode.f1, altKey: true });

--- a/lib/components/Field/FormField.tsx
+++ b/lib/components/Field/FormField.tsx
@@ -96,6 +96,11 @@ export class FormField extends React.PureComponent<FormFieldProps, FormFieldStat
             });
             e.preventDefault();
             e.stopPropagation();
+        } else if (e.keyCode === keyCode.tab) {
+            // BUG 3217787: if the user tabs out, close the tooltip and continue to default behavior:
+            this.setState({
+                tooltipVisible: false
+            });
         }
     }
 

--- a/lib/components/List/GenericManagementList.tsx
+++ b/lib/components/List/GenericManagementList.tsx
@@ -132,10 +132,10 @@ export class GenericManagementList<T> extends React.PureComponent<GenericManagem
     render() {
         let columns = this.props.columns.map(col => []);
         this.props.columns.forEach((column, colIndex) => {
-            let onClick: (event) => void = null;
-            let labelSuffix: MethodNode = '';
             const sortable = column.onAscending && column.onDescending;
             if (sortable) {
+                let labelSuffix: MethodNode = '';
+                let onClick: (event) => void = null;
                 if (this.props.sortedColumn === column) {
                     let icon = '';
                     if (this.props.sortDirection === 'descending') {
@@ -156,19 +156,32 @@ export class GenericManagementList<T> extends React.PureComponent<GenericManagem
                         ? event => column.onDescending()
                         : event => column.onAscending();
                 }
+                
+                columns[colIndex].push(
+                    <Attr.button
+                        type='button'
+                        className={css('column-header')}
+                        key={`header-${colIndex}`}
+                        onClick={onClick}
+                        attr={this.props.attr.rowHeaderButton}
+                    >
+                        {column.label}{labelSuffix}
+                    </Attr.button>
+                );
+            } else {
+                // BUG 2383275: narrator should not read non-interactive column headers as Buttons,
+                // so if the column is not sortable, emit a <header> tag, not a <button>:
+                columns[colIndex].push(
+                    <Attr.header
+                        className={css('column-header')}
+                        key={`header-${colIndex}`}
+                        attr={this.props.attr.rowHeaderButton}
+                    >
+                        {column.label}
+                    </Attr.header>
+                );
             }
-            columns[colIndex].push(
-                <Attr.button
-                    type='button'
-                    className={css('column-header')}
-                    key={`header-${colIndex}`}
-                    onClick={onClick}
-                    disabled={!sortable}
-                    attr={this.props.attr.rowHeaderButton}
-                >
-                    {column.label}{labelSuffix}
-                </Attr.button>
-            );
+            
             columns[colIndex].push(
                 this.props.rows.map((row, rowIndex) => {
                     let content;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "5.2.1",
+    "version": "5.2.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "5.2.1",
+    "version": "5.2.2-alpha.1",
     "description": "Azure IoT UX Fluent Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "5.2.2-alpha.1",
+    "version": "5.2.2",
     "description": "Azure IoT UX Fluent Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",


### PR DESCRIPTION
Fixed
- [BUG 3217787](): [Form Field] If the user tabs out of a field when the tooltip button is open (Alt+F1), close the tooltip.
- [BUG 2383275](https://msazure.visualstudio.com/One/_workitems/edit/2383275): [Management List] Narrator should not read non-interactive column headers as Buttons.