### PR TITLE
Add Context Panel

### DIFF
--- a/lib/components/ContextPanel/ContextPanel.md
+++ b/lib/components/ContextPanel/ContextPanel.md
@@ -1,6 +1,6 @@
 ______________________________________________________________________________
 
-### `ContentPanel.props.attr`
+### `ContextPanel.props.attr`
 
 ```html
 <ContextPanel
@@ -19,19 +19,19 @@ ______________________________________________________________________________
 const Btn = require('../Button').Button;
 <ContextPanel 
     header='Hello'
+    children={<div>This is context panel 1</div>}
     footer={<Btn icon='cancel' onClick={()=> alert('cancel triggered')} attr={{ container: { autoFocus: true }}}>Cancel</Btn>}
     onClose={()=> alert('cancel triggered')}
->
-    This is context panel 1          
-</ContextPanel>
+/>
 ```
 
 ```jsx
 const Btn = require('../Button').Button;
 <ContextPanel 
     header={<div>Hello</div>}
-    children={<div>This is context panel 1</div>}
     footer={<Btn icon='cancel' onClick={()=> alert('cancel triggered')} attr={{ container: { autoFocus: true }}}>Cancel</Btn>}
     onClose={()=> alert('cancel triggered')}
-/>
+>
+    This is context panel 1          
+</ContextPanel>
 ```

--- a/lib/components/ContextPanel/ContextPanel.md
+++ b/lib/components/ContextPanel/ContextPanel.md
@@ -3,13 +3,13 @@ ______________________________________________________________________________
 ### `ContentPanel.props.attr`
 
 ```html
-<ContentPanel
+<ContextPanel
     header={...props.header: React.ReactNode}
     footer={...props.footer: React.ReactNode}
     onClose={...props.onClose: React.EventHandler<any>}
 >
     Hello, World!
-</ContentPanel>
+</ContextPanel>
 ```
 ______________________________________________________________________________
 
@@ -24,4 +24,14 @@ const Btn = require('../Button').Button;
 >
     This is context panel 1          
 </ContextPanel>
+```
+
+```jsx
+const Btn = require('../Button').Button;
+<ContextPanel 
+    header={<div>Hello</div>}
+    children={<div>This is context panel 1</div>}
+    footer={<Btn icon='cancel' onClick={()=> alert('cancel triggered')} attr={{ container: { autoFocus: true }}}>Cancel</Btn>}
+    onClose={()=> alert('cancel triggered')}
+/>
 ```

--- a/lib/components/ContextPanel/ContextPanel.md
+++ b/lib/components/ContextPanel/ContextPanel.md
@@ -1,0 +1,34 @@
+______________________________________________________________________________
+
+### `ContentPanel.props.attr`
+
+```html
+<ContentPanel
+    title={...props.title: string}
+    content={...props.content: React.ReactNode | string}
+    action: {  
+        confirm:{
+            label: string;
+            event: Function;
+        },
+        cancel:{ 
+            label: string;
+            event: Function;
+        }
+    }
+/>
+```
+______________________________________________________________________________
+
+### Examples
+
+```jsx
+<ContentPanel 
+    title={'Content Panel'}
+    content={<div style={{height: '200px', width: '100%', background:'red', color: 'white', padding:'10px'}}>this is a string content</div>}
+    actions={{ 
+        confirm:{ label: 'action', event: ()=> alert('action triggered')},
+        cancel:{ label: 'action', event: ()=> alert('cancel triggered')}
+    }}
+/>
+```

--- a/lib/components/ContextPanel/ContextPanel.md
+++ b/lib/components/ContextPanel/ContextPanel.md
@@ -4,31 +4,24 @@ ______________________________________________________________________________
 
 ```html
 <ContentPanel
-    title={...props.title: string}
-    content={...props.content: React.ReactNode | string}
-    action: {  
-        confirm:{
-            label: string;
-            event: Function;
-        },
-        cancel:{ 
-            label: string;
-            event: Function;
-        }
-    }
-/>
+    header={...props.header: React.ReactNode}
+    footer={...props.footer: React.ReactNode}
+    onClose={...props.onClose: React.EventHandler<any>}
+>
+    Hello, World!
+</ContentPanel>
 ```
 ______________________________________________________________________________
 
 ### Examples
 
 ```jsx
-<ContentPanel 
-    title={'Content Panel'}
-    content={<div style={{height: '200px', width: '100%', background:'red', color: 'white', padding:'10px'}}>this is a string content</div>}
-    actions={{ 
-        confirm:{ label: 'action', event: ()=> alert('action triggered')},
-        cancel:{ label: 'action', event: ()=> alert('cancel triggered')}
-    }}
-/>
+const Btn = require('../Button').Button;
+<ContextPanel 
+    header='Hello'
+    footer={<Btn icon='cancel' onClick={()=> alert('cancel triggered')} attr={{ container: { autoFocus: true }}}>Cancel</Btn>}
+    onClose={()=> alert('cancel triggered')}
+>
+    This is context panel 1          
+</ContextPanel>
 ```

--- a/lib/components/ContextPanel/ContextPanel.module.scss
+++ b/lib/components/ContextPanel/ContextPanel.module.scss
@@ -1,0 +1,93 @@
+@import '../../common/color.controls';
+@import '../../common/constants';
+@import '../../common/mixins';
+
+$content-pane-width: 320px;
+$title-font-size: 20px;
+$close-icon-height: $grid-size * 8;
+$title-height: $gutter-xsmall+$title-font-size;
+$box-shadow-panel: 0 25.6px 57.6px 0 rgba(0, 0, 0, .12);
+
+.content-panel {
+    position: absolute;
+    right: 0;
+    height: 100%;
+    width: $content-pane-width;
+    display: flex;
+    flex-direction: column;
+    padding: $gutter-normal;
+    box-shadow: $box-shadow-panel;
+    
+    @include rtl {
+        right: unset;
+        left: 0;
+    }
+
+    @media(max-width: $screen-md) {
+        width: 100%;
+    }
+
+    @include themify {
+        background-color: themed('color-bg-searchbar');
+    }
+}
+
+@keyframes slide-fade-in {
+    0% {
+        transform: translate($content-pane-width, 0);
+        opacity: 0;
+    }
+
+    100% {
+        transform: translate(0, 0);
+        opacity: 1;
+    }
+}
+
+.close-button {
+    align-self: flex-end;
+    margin: -$gutter-normal;
+}
+
+.title {
+    font-size: $title-font-size;
+    margin-top: 2*$grid-size;
+    margin-bottom: $gutter-big;
+}
+
+.content {
+    flex-grow: 1;
+    flex-shrink: 2;
+    overflow: auto;
+
+    animation-name: slide-fade-in;
+    animation-duration: .5s;
+    animation-timing-function: cubic-bezier(.8, 0, .2, 1);
+    animation-fill-mode: backwards;
+    animation-delay: 80ms;
+}
+
+.separator {
+    margin-left: -$gutter-normal;
+    margin-right: -$gutter-normal;
+    @include themify {
+        border-top: 1px solid themed('color-border-navbar-separator');
+    }
+}
+
+.footer {
+    margin-top: $gutter-normal;
+
+    :global(.btn) {
+        margin: 0;
+        width: 3*$gutter-bigger;
+    }
+
+    :global(.btn):first-child {
+        margin-right: $gutter-xsmall;
+        @include rtl {
+            margin-right: 0;
+            margin-left: $gutter-xsmall;
+        }
+    }
+}

--- a/lib/components/ContextPanel/ContextPanel.module.scss
+++ b/lib/components/ContextPanel/ContextPanel.module.scss
@@ -2,26 +2,35 @@
 @import '../../common/constants';
 @import '../../common/mixins';
 
-$content-pane-width: 320px;
-$title-font-size: 20px;
-$close-icon-height: $grid-size * 8;
-$title-height: $gutter-xsmall+$title-font-size;
+$content-pane-width: 8*$gutter-bigger;
+$content-pane-min-height: 5*$gutter-bigger; // at least enough for title + actions
+$title-font-size: $gutter-normal;
 $box-shadow-panel: 0 25.6px 57.6px 0 rgba(0, 0, 0, .12);
+
+
+@keyframes slide-in-from-right {
+    0% { transform: translateX(100%); }
+    100% { transform: translateX(0); }
+}
+
+@keyframes slide-in-from-left {
+    0% { transform: translateX(-100%); }
+    100% { transform: translateX(0); }
+}
 
 .content-panel {
     position: absolute;
     right: 0;
     height: 100%;
+    min-height: $content-pane-min-height;
     width: $content-pane-width;
     display: flex;
     flex-direction: column;
     padding: $gutter-normal;
     box-shadow: $box-shadow-panel;
-    
-    @include rtl {
-        right: unset;
-        left: 0;
-    }
+    z-index: $z-index-flyout-layer;
+    animation-name: slide-in-from-right;
+    animation-duration: $interaction-timing;
 
     @media(max-width: $screen-md) {
         width: 100%;
@@ -30,17 +39,11 @@ $box-shadow-panel: 0 25.6px 57.6px 0 rgba(0, 0, 0, .12);
     @include themify {
         background-color: themed('color-bg-searchbar');
     }
-}
-
-@keyframes slide-fade-in {
-    0% {
-        transform: translate($content-pane-width, 0);
-        opacity: 0;
-    }
-
-    100% {
-        transform: translate(0, 0);
-        opacity: 1;
+    
+    @include rtl {
+        right: unset;
+        left: 0;
+        animation-name: slide-in-from-left;
     }
 }
 
@@ -53,18 +56,14 @@ $box-shadow-panel: 0 25.6px 57.6px 0 rgba(0, 0, 0, .12);
     font-size: $title-font-size;
     margin-top: 2*$grid-size;
     margin-bottom: $gutter-big;
+    flex-grow: 0;
+    flex-shrink: 0;
 }
 
 .content {
     flex-grow: 1;
-    flex-shrink: 2;
+    flex-shrink: 1;
     overflow: auto;
-
-    animation-name: slide-fade-in;
-    animation-duration: .5s;
-    animation-timing-function: cubic-bezier(.8, 0, .2, 1);
-    animation-fill-mode: backwards;
-    animation-delay: 80ms;
 }
 
 .separator {
@@ -76,6 +75,8 @@ $box-shadow-panel: 0 25.6px 57.6px 0 rgba(0, 0, 0, .12);
 }
 
 .footer {
+    flex-grow: 0;
+    flex-shrink: 0;
     margin-top: $gutter-normal;
 
     :global(.btn) {

--- a/lib/components/ContextPanel/ContextPanel.module.scss
+++ b/lib/components/ContextPanel/ContextPanel.module.scss
@@ -5,20 +5,8 @@
 $content-pane-width: 8*$gutter-bigger;
 $content-pane-min-height: 5*$gutter-bigger; // at least enough for title + actions
 $title-font-size: $gutter-normal;
-$box-shadow-panel: 0 25.6px 57.6px 0 rgba(0, 0, 0, .12);
 
-
-@keyframes slide-in-from-right {
-    0% { transform: translateX(100%); }
-    100% { transform: translateX(0); }
-}
-
-@keyframes slide-in-from-left {
-    0% { transform: translateX(-100%); }
-    100% { transform: translateX(0); }
-}
-
-.content-panel {
+.panel {
     position: absolute;
     right: 0;
     height: 100%;
@@ -27,23 +15,20 @@ $box-shadow-panel: 0 25.6px 57.6px 0 rgba(0, 0, 0, .12);
     display: flex;
     flex-direction: column;
     padding: $gutter-normal;
-    box-shadow: $box-shadow-panel;
     z-index: $z-index-flyout-layer;
-    animation-name: slide-in-from-right;
-    animation-duration: $interaction-timing;
 
     @media(max-width: $screen-md) {
         width: 100%;
     }
 
     @include themify {
-        background-color: themed('color-bg-searchbar');
+        background-color: themed('color-bg-panel-contextual');
+        box-shadow: themed('shadow-panel-contextual')
     }
     
     @include rtl {
         right: unset;
         left: 0;
-        animation-name: slide-in-from-left;
     }
 }
 
@@ -70,7 +55,7 @@ $box-shadow-panel: 0 25.6px 57.6px 0 rgba(0, 0, 0, .12);
     margin-left: -$gutter-normal;
     margin-right: -$gutter-normal;
     @include themify {
-        border-top: 1px solid themed('color-border-navbar-separator');
+        border-top: 1px solid themed('color-border-panel-contextual-separator');
     }
 }
 

--- a/lib/components/ContextPanel/ContextPanel.spec.tsx
+++ b/lib/components/ContextPanel/ContextPanel.spec.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { ContextPanel } from './ContextPanel';
+import { describe, it } from 'mocha';
+
+describe('<ContentPanel />', () => {
+    it('properly passes title and content string', () => {
+        const wrapper = shallow(<ContextPanel
+            header='title'
+            content='test-content'
+            actions={{
+                cancel: {
+                    event: () => { },
+                    label: 'label'
+                }
+            }}
+        />);
+
+        expect(wrapper.html()).to.equal('<div role="complementary" class="content-panel sm md"><button type="button" class="action-trigger-button close-button"><div class="action-trigger-container action-trigger-label-empty"><span aria-label="close-panel" class="icon-xsmall icon-cancel"></span></div></button><div class="title inline-text-overflow">title </div><div class="content">test-content</div></div>');
+        expect(wrapper.contains('test-content')).to.equal(true);
+    });
+
+    it('properly passes title and content DOM', () => {
+        const wrapper = shallow(<ContextPanel
+            header='title'
+            content={<div>test-content-div</div>}
+            actions={{
+                cancel: {
+                    event: () => { },
+                    label: 'label'
+                }
+            }}
+        />);
+
+        expect(wrapper.html()).to.equal('<div role="complementary" class="content-panel sm md"><button type="button" class="action-trigger-button close-button"><div class="action-trigger-container action-trigger-label-empty"><span aria-label="close-panel" class="icon-xsmall icon-cancel"></span></div></button><div class="title inline-text-overflow">title </div><div class="content"><div>test-content-div</div></div></div>');
+    });
+
+    it('properly passes title, content and action', () => {
+        const wrapper = shallow(<ContextPanel
+            header='title'
+            content={<div>test-content-div</div>}
+            actions={{
+                confirm: { label: 'action', event: () => alert('action triggered') },
+                cancel: { label: 'action', event: () => alert('cancel triggered') }
+            }}
+        />);
+        expect(wrapper.html()).to.equal('<div role="complementary" class="content-panel sm md"><button type="button" class="action-trigger-button close-button"><div class="action-trigger-container action-trigger-label-empty"><span aria-label="close-panel" class="icon-xsmall icon-cancel"></span></div></button><div class="title inline-text-overflow">title </div><div class="content"><div>test-content-div</div></div><span class="separator"></span><div class="actions"><button type="button" class="btn btn btn-primary inline-text-overflow">action</button><button type="button" autofocus="" class="btn btn btn-default inline-text-overflow">action</button></div></div>');
+    });
+
+});

--- a/lib/components/ContextPanel/ContextPanel.spec.tsx
+++ b/lib/components/ContextPanel/ContextPanel.spec.tsx
@@ -5,47 +5,24 @@ import { ContextPanel } from './ContextPanel';
 import { describe, it } from 'mocha';
 
 describe('<ContentPanel />', () => {
-    it('properly passes title and content string', () => {
-        const wrapper = shallow(<ContextPanel
-            header='title'
-            content='test-content'
-            actions={{
-                cancel: {
-                    event: () => { },
-                    label: 'label'
-                }
-            }}
-        />);
+    it('properly passes header, footer, and content strings', () => {
+        const wrapper = shallow(
+            <ContextPanel header='header' footer='footer' onClose={() => {}}>
+                content
+            </ContextPanel>
+        );
 
-        expect(wrapper.html()).to.equal('<div role="complementary" class="content-panel sm md"><button type="button" class="action-trigger-button close-button"><div class="action-trigger-container action-trigger-label-empty"><span aria-label="close-panel" class="icon-xsmall icon-cancel"></span></div></button><div class="title inline-text-overflow">title </div><div class="content">test-content</div></div>');
-        expect(wrapper.contains('test-content')).to.equal(true);
+        expect(wrapper.contains('header'), 'header');
+        expect(wrapper.contains('content'), 'content');
+        expect(wrapper.contains('footer'), 'footer');
+    }); 
+    
+    it('works without a footer', () => {
+        const wrapper = shallow(
+            <ContextPanel header='header' onClose={() => {}}>content</ContextPanel>
+        );
+
+        expect(wrapper.contains('header'), 'header');
+        expect(wrapper.contains('content'), 'content');
     });
-
-    it('properly passes title and content DOM', () => {
-        const wrapper = shallow(<ContextPanel
-            header='title'
-            content={<div>test-content-div</div>}
-            actions={{
-                cancel: {
-                    event: () => { },
-                    label: 'label'
-                }
-            }}
-        />);
-
-        expect(wrapper.html()).to.equal('<div role="complementary" class="content-panel sm md"><button type="button" class="action-trigger-button close-button"><div class="action-trigger-container action-trigger-label-empty"><span aria-label="close-panel" class="icon-xsmall icon-cancel"></span></div></button><div class="title inline-text-overflow">title </div><div class="content"><div>test-content-div</div></div></div>');
-    });
-
-    it('properly passes title, content and action', () => {
-        const wrapper = shallow(<ContextPanel
-            header='title'
-            content={<div>test-content-div</div>}
-            actions={{
-                confirm: { label: 'action', event: () => alert('action triggered') },
-                cancel: { label: 'action', event: () => alert('cancel triggered') }
-            }}
-        />);
-        expect(wrapper.html()).to.equal('<div role="complementary" class="content-panel sm md"><button type="button" class="action-trigger-button close-button"><div class="action-trigger-container action-trigger-label-empty"><span aria-label="close-panel" class="icon-xsmall icon-cancel"></span></div></button><div class="title inline-text-overflow">title </div><div class="content"><div>test-content-div</div></div><span class="separator"></span><div class="actions"><button type="button" class="btn btn btn-primary inline-text-overflow">action</button><button type="button" autofocus="" class="btn btn btn-default inline-text-overflow">action</button></div></div>');
-    });
-
 });

--- a/lib/components/ContextPanel/ContextPanel.tsx
+++ b/lib/components/ContextPanel/ContextPanel.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import * as classnames from 'classnames/bind';
+import { ActionTriggerButton, ActionTriggerButtonAttributes, ActionTriggerAttributes } from '../ActionTrigger';
+import { Elements as Attr, DivProps, HeaderProps, FooterProps } from '../../Attributes';
+import { Portal } from './portal';
+
+const cx = classnames.bind(require('./ContextPanel.module.scss'));
+
+export interface ContextPanelProperties {
+    header: React.ReactNode;
+    children?: React.ReactNode;
+    footer?: React.ReactNode;
+    onClose: React.EventHandler<any>;
+    attr?: {
+        header?: HeaderProps;
+        childContainer?: DivProps;
+        footer?: FooterProps;
+        closeButton?: ActionTriggerButtonAttributes & ActionTriggerAttributes;
+    };
+}
+
+export function ContextPanel({ header, children, footer, onClose, attr }: ContextPanelProperties) {
+    return (
+        <Portal>
+            <Attr.div key='context-panel' role='dialog' aria-labelledby='context-panel-title' aria-describedby='context-panel-content' className={cx('content-panel')}>
+                <ActionTriggerButton
+                    icon='cancel'
+                    className={cx('close-button')}
+                    onClick={onClose}
+                    attr={attr && attr.closeButton}
+                />
+                <Attr.header id='context-panel-title' className={cx('title', 'inline-text-overflow')} attr={attr && attr.header}>{header}</Attr.header>
+                <Attr.div id='context-panel-content' className={cx('content')} attr={attr && attr.childContainer}>
+                    {children}
+                </Attr.div>
+                {footer && <React.Fragment>
+                    <span className={cx('separator')} />
+                    <Attr.footer className={cx('footer')} attr={attr && attr.footer}>{footer}</Attr.footer>
+                </React.Fragment>}
+            </Attr.div>
+        </Portal>
+    );
+}
+
+export default ContextPanel;

--- a/lib/components/ContextPanel/ContextPanel.tsx
+++ b/lib/components/ContextPanel/ContextPanel.tsx
@@ -27,7 +27,7 @@ export function ContextPanel({ header, children, footer, onClose, attr }: Contex
                 role='complementary' 
                 aria-labelledby='context-panel-title' 
                 aria-describedby='context-panel-content' 
-                className={cx('content-panel')} 
+                className={cx('panel')} 
                 attr={attr && attr.container}
             >
                 {onClose && <ActionTriggerButton

--- a/lib/components/ContextPanel/ContextPanel.tsx
+++ b/lib/components/ContextPanel/ContextPanel.tsx
@@ -7,13 +7,14 @@ import { Portal } from './portal';
 const cx = classnames.bind(require('./ContextPanel.module.scss'));
 
 export interface ContextPanelProperties {
+    onClose: React.EventHandler<any>;
     header: React.ReactNode;
     children?: React.ReactNode;
     footer?: React.ReactNode;
-    onClose: React.EventHandler<any>;
     attr?: {
+        container?: DivProps;
         header?: HeaderProps;
-        childContainer?: DivProps;
+        content?: DivProps;
         footer?: FooterProps;
         closeButton?: ActionTriggerButtonAttributes & ActionTriggerAttributes;
     };
@@ -22,15 +23,27 @@ export interface ContextPanelProperties {
 export function ContextPanel({ header, children, footer, onClose, attr }: ContextPanelProperties) {
     return (
         <Portal>
-            <Attr.div key='context-panel' role='dialog' aria-labelledby='context-panel-title' aria-describedby='context-panel-content' className={cx('content-panel')}>
-                <ActionTriggerButton
+            <Attr.div 
+                role='complementary' 
+                aria-labelledby='context-panel-title' 
+                aria-describedby='context-panel-content' 
+                className={cx('content-panel')} 
+                attr={attr && attr.container}
+            >
+                {onClose && <ActionTriggerButton
                     icon='cancel'
                     className={cx('close-button')}
                     onClick={onClose}
                     attr={attr && attr.closeButton}
-                />
-                <Attr.header id='context-panel-title' className={cx('title', 'inline-text-overflow')} attr={attr && attr.header}>{header}</Attr.header>
-                <Attr.div id='context-panel-content' className={cx('content')} attr={attr && attr.childContainer}>
+                />}
+                {header && <Attr.header 
+                    id='context-panel-title' 
+                    className={cx('title', 'inline-text-overflow')} 
+                    attr={attr && attr.header}
+                    >
+                    {header}
+                </Attr.header>}
+                <Attr.div id='context-panel-content' className={cx('content')} attr={attr && attr.content}>
                     {children}
                 </Attr.div>
                 {footer && <React.Fragment>

--- a/lib/components/ContextPanel/index.ts
+++ b/lib/components/ContextPanel/index.ts
@@ -1,0 +1,2 @@
+export * from './ContextPanel';
+

--- a/lib/components/ContextPanel/portal.tsx
+++ b/lib/components/ContextPanel/portal.tsx
@@ -17,6 +17,12 @@ export class Portal extends React.Component<Properties, State> {
     }
 
     componentDidMount() {
+        // The portal root element won't be present on initial render, or if 
+        // we're rendering server-side. Therefore, wait till this component has
+        // been mounted and then create the portal. This also allows us to use
+        // autoFocus in a descendant (otherwise, the portal element is inserted
+        // in the DOM tree after the children are mounted, meaning that children
+        // will be mounted on a detached DOM node)
         const container = document.getElementById(RootElementId);
         this.setState({ container });
     }

--- a/lib/components/ContextPanel/portal.tsx
+++ b/lib/components/ContextPanel/portal.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import { ElementId as RootElementId } from './root';
+
+interface Properties {
+    children?: React.ReactNode;
+}
+
+interface State {
+    container?: HTMLElement;
+}
+
+export class Portal extends React.Component<Properties, State> {
+    constructor(props: Properties) {
+        super(props);
+        this.state = {};
+    }
+
+    componentDidMount() {
+        const container = document.getElementById(RootElementId);
+        this.setState({ container });
+    }
+
+    render() {
+        const { container } = this.state;
+        if (!container) {
+            return null;
+        }
+
+        return createPortal(this.props.children, container);
+    }
+}

--- a/lib/components/ContextPanel/root.tsx
+++ b/lib/components/ContextPanel/root.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+export const ElementId = 'context-panel-root';
+
+export function Root() {
+    return <div id={ElementId}></div>;
+}

--- a/lib/components/Shell/Shell.module.scss
+++ b/lib/components/Shell/Shell.module.scss
@@ -57,7 +57,11 @@
     // lay out nav and workspace horizontally:
     display: flex;
     height: 100%;
-    position: relative; // required for context panel
+    width: 100%;
+    
+    // required for context panel:
+    overflow: hidden;
+    position: relative; 
 }
 
 .workspace {

--- a/lib/components/Shell/Shell.module.scss
+++ b/lib/components/Shell/Shell.module.scss
@@ -57,6 +57,7 @@
     // lay out nav and workspace horizontally:
     display: flex;
     height: 100%;
+    position: relative; // required for context panel
 }
 
 .workspace {

--- a/lib/components/Shell/Shell.tsx
+++ b/lib/components/Shell/Shell.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as classnames from 'classnames/bind';
 import { Masthead, MastheadProperties } from '../Masthead/Masthead';
 import { Navigation, NavigationProperties } from '../Navigation/Navigation';
+import { Root as ContextPanelRoot } from '../ContextPanel/root';
 
 // reexport Masthead and Nav Properties for easier consumption by consumers:
 export { MastheadProperties } from '../Masthead/Masthead';
@@ -32,6 +33,7 @@ export function Shell({ theme, isRtl, masthead, navigation, children, onClick }:
                     <div className={css('workspace')}>
                         {children}
                     </div>
+                    <ContextPanelRoot />
                 </div>
             </div>
         </div>

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,6 +3,7 @@ export * from './components/ActionTrigger';
 export * from './components/Alert';
 export * from './components/Balloon';
 export * from './components/Button';
+export * from './components/ContextPanel';
 export * from './components/DateTime';
 export * from './components/Dropdown';
 export * from './components/Field';

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = {
   title: 'Azure IoT Fluent Controls Documentation',
-  components: 'lib/components/**/*.{ts,tsx}',
+  components: 'lib/components/**/[A-Z]*.tsx',
   ignore: ['**/*.spec.{js,jsx,ts,tsx}', '**/*.d.ts', '**/index.ts'],
   resolver: require('react-docgen').resolver.findAllComponentDefinitions,
 
@@ -11,6 +11,7 @@ module.exports = {
   assetsDir: './docs/',
   webpackConfig: require('./webpack.styleguide.js'),
 
+  skipComponentsWithoutExample: true,
   styleguideDir: './dist/',
   styleguideComponents: {
     Wrapper: path.join(__dirname, 'lib/components/Shell/Shell'),


### PR DESCRIPTION
This PR adds a Context Panel (flyout in RM terms) to the Fluent Controls, since it's now a common shared component in the new design language intended for App Settings, Documentation etc. The styling is mostly the same as the ContentPanel that Vincenzo added as part of the new Masthead, but after last week's discussion, the design has been changed to be more generic so we can reuse the panel outside the Masthead as well.

Usage:
```tsx
<ContextPanel 
    header='Hello'
    footer={<Btn icon='cancel' onClick={()=> alert('cancel triggered')} attr={{ container: { autoFocus: true }}}>Cancel</Btn>}
    onClose={()=> alert('cancel triggered')}
>
    This is context panel 1          
</ContextPanel>
```

The ContextPanel takes in the following properties:
```ts
interface ContextPanelProperties {
    onClose: React.EventHandler<any>;
    header: React.ReactNode;
    children?: React.ReactNode;
    footer?: React.ReactNode;
}
```

I used the [slots pattern](https://daveceddia.com/pluggable-slots-in-react-components/) mainly because:
1. We want to force all context panels to have a header and close button.
2. The container styling requires the children to be placed in a very specific order (close button -> header -> content -> footer), so it's easy for consumers to get it wrong.

There's a big discussion going on in the community about this approach vs named components ([see Dan Abramov's comments](https://github.com/jxnblk/macro-components/issues/3) for an example), so let me know what you guys think. The other approach, roughly, is:
```tsx
<ContextPanel>
    <ContextPanel.CloseButton onClick={...} />
    <ContextPanel.Header>Foo</ContextPanel.Header>
    <ContextPanel.Content>Bar</ContextPanel.Content>
    <ContextPanel.Footer>Baz</ContextPanel.Footer>
</ContextPanel>
```

Since this is now a generic component, the ContextPanel now renders [through a portal](https://reactjs.org/docs/portals.html) under a dedicated root div in the shell.