### PR TITLE
Fix line height of select input to avoid cutting text with browser zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v6.0.5
+### Fixed
+- BUG 3870819: [Select Input] Text in select field should not be cut off with browser zoom.
+
 ## v6.0.4
 ### Fixed
 - Handling the error during the download of the thumbnail. Instead to show the broken images symbol, fallback to the default user-icon.

--- a/lib/components/Input/SelectInput.module.scss
+++ b/lib/components/Input/SelectInput.module.scss
@@ -29,6 +29,7 @@ $line-height: 4*$grid-size;
         @include md-box();
         width: 100%;
         height: $input-height;
+        line-height: $input-height;
         padding: 0 6*$grid-size 0 3*$grid-size;
         outline: none;
         -webkit-appearance: none;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "6.0.4",
+    "version": "6.0.5",
     "description": "Azure IoT UX Fluent Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",


### PR DESCRIPTION
Fix bug 3870819. 

![f2d11931-9ea0-4f11-af43-784bbb3219ac](https://user-images.githubusercontent.com/2132567/53037493-36435380-342f-11e9-8dbc-a99f13ee6d99.png)
