### PR TITLE
Fix padding of action bar items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v6.0.8
+### Fixed
+- Updated ActionTrigger to have correct sizes so outline is not cutted when the element is focused and hover.
+
 ## v6.0.7
 ### Changed
  - Updated the user type in masthead to JSX.Element

--- a/lib/components/ActionTrigger/ActionTrigger.module.scss
+++ b/lib/components/ActionTrigger/ActionTrigger.module.scss
@@ -9,7 +9,7 @@ $line-height: 4.5*$grid-size;
     font-family: $font-family-default;
     font-size: $icon-size-xsmall;
     line-height: $line-height;
-    padding: 1.5*$grid-size 2*$grid-size;
+    padding: 0 $grid-size;
     @include themify {
         color: themed('color-text-rest');
     }
@@ -82,6 +82,7 @@ $line-height: 4.5*$grid-size;
 .action-trigger-button {
     @include md-button-reset();
     line-height: 0px;
+    padding: $grid-size;
 
     &.disabled {
         cursor: not-allowed;

--- a/lib/components/ActionTrigger/ActionTrigger.module.scss
+++ b/lib/components/ActionTrigger/ActionTrigger.module.scss
@@ -9,7 +9,7 @@ $line-height: 4.5*$grid-size;
     font-family: $font-family-default;
     font-size: $icon-size-xsmall;
     line-height: $line-height;
-    padding: $grid-size 2*$grid-size;
+    padding: 1.5*$grid-size 2*$grid-size;
     @include themify {
         color: themed('color-text-rest');
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "6.0.4",
+    "version": "6.0.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "6.0.7",
+    "version": "6.0.8",
     "description": "Azure IoT UX Fluent Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",


### PR DESCRIPTION
Fixed the padding in action trigger items. This was showing an inconsistency in the hover of focused buttons because the outline would not completely dissapear.

**Before:**
Focused: ![7](https://user-images.githubusercontent.com/2132567/53529282-fcaec000-3aa0-11e9-9832-038b5d739d37.PNG)
Focused & Hover: ![8](https://user-images.githubusercontent.com/2132567/53529283-fcaec000-3aa0-11e9-9b32-75c08caf0703.PNG)

**After:**
Focused: ![5](https://user-images.githubusercontent.com/2132567/53529119-8c07a380-3aa0-11e9-89bd-a7838d82a886.PNG)
Focused & Hover: ![6](https://user-images.githubusercontent.com/2132567/53529120-8ca03a00-3aa0-11e9-8c67-48ca98bb33ef.PNG)

This bug only repros in Chrome and Edge, the fix works in both browsers and does not repro the UI of other browsers (in both Windows and Mac).