### PR TITLE
Remove references for non-existing file

### DIFF
--- a/lib/components/ActionTrigger/ActionTrigger.tsx
+++ b/lib/components/ActionTrigger/ActionTrigger.tsx
@@ -3,7 +3,6 @@ import * as classNames from 'classnames/bind';
 
 import { Icon, IconSize, IconAttributes } from '../Icon';
 import { Elements as Attr, DivProps } from '../../Attributes';
-import { StyledElements } from '../../Styled';
 
 const css = classNames.bind(require('./ActionTrigger.module.scss'));
 

--- a/lib/components/ActionTrigger/ActionTriggerButton.tsx
+++ b/lib/components/ActionTrigger/ActionTriggerButton.tsx
@@ -3,7 +3,6 @@ import * as classNames from 'classnames/bind';
 import styled, { ThemeProvider, ThemeProps} from 'styled-components';
 
 import { MethodNode } from '../../Common';
-import { StyledElements } from '../../Styled';
 import { ActionTrigger, ActionTriggerProps, ActionTriggerAttributes } from '../ActionTrigger';
 import { Elements as Attr, ButtonProps } from '../../Attributes';
 import { ShellTheme  } from '../Shell';

--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -3,7 +3,6 @@ import * as classnames from 'classnames/bind';
 import styled, { ThemeProps } from 'styled-components';
 
 import { SpanProps, ButtonProps as AttrButtonProps, Elements as Attr } from '../../Attributes';
-import { StyledElements } from '../../Styled';
 import { ShellTheme } from '../Shell';
 const css = classnames.bind(require('./Button.module.scss'));
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -18,4 +18,3 @@ export * from './components/Shell';
 export * from './components/Thumbnail';
 export * from './components/Toggle';
 export * from './Common';
-export * from './Styled';


### PR DESCRIPTION
Last PR removed `Styles.ts` but there were some references that we missed. This is mainly to fix the build of the package.