### PR TITLE
Give its own class to inner far side container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # CHANGELOG
+## v6.2.3
+### Fixed
+- Add the far side container of the form field label only if a far side item is present. 
+- Update styles of far side container of form field label.
 
 ## v6.2.2
 ### Added
- - Added ability to include an extra node to the far side of the label in form fields.
+- Added ability to include an extra node to the far side of the label in form fields.
 
 ## v6.2.1
 ### Fixed
- - BUG 4445327: Masthead: hover color regression on action buttons
+- BUG 4445327: Masthead: hover color regression on action buttons
 
 ## v6.2.0
 - Refactor component styling logic using ThemeProvider in styled component library.

--- a/lib/components/Field/Field.module.scss
+++ b/lib/components/Field/Field.module.scss
@@ -63,9 +63,15 @@ $line-height: 5*$grid-size;
     }
 }
 
+.label-farSide-container {
+    @include md-box(flex-row);
+    align-items: flex-end;
+}
+
 .label-inner-container {
     @include md-box(flex-row);
     align-items: flex-end;
+    flex: 1;
 }
 
 .field-error {

--- a/lib/components/Field/FormLabel.tsx
+++ b/lib/components/Field/FormLabel.tsx
@@ -11,6 +11,7 @@ export interface FormLabelType {}
 export interface FormLabelAttributes {
     container?: DivProps;
     innerContainer?: DivProps;
+    farSideContainer?: DivProps;
     text?: LabelProps;
     icon?: IconAttributes;
     balloon?: BalloonAttributes;
@@ -118,11 +119,11 @@ export const FormLabel: React.StatelessComponent<FormLabelProps> = (props: FormL
                 </Attr.label>
                 {balloon}
             </Attr.div>
-            <Attr.div
-                className={css('label-inner-container')}
-                attr={props.attr.innerContainer}>
+            {props.farSide && <Attr.div
+                className={css('label-farSide-container')}
+                attr={props.attr.farSideContainer}>
                 {props.farSide}
-            </Attr.div>
+            </Attr.div>}
         </Attr.div>
     );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "6.2.2",
+    "version": "6.2.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "6.2.2",
+    "version": "6.2.3",
     "description": "Azure IoT UX Fluent Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",


### PR DESCRIPTION
In the form field label the far side container should not appear if the far side is not there. Also, it should have it's own class so we can access it directly with the attr.