### PR TITLE
Fix displaying the rightIcon on actiontiggerbutton correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v6.3.2
+### Fixed
+- Fix styling on action trigger button right icon.
+
 ## v6.3.1
 ### Fixed
 - Fix styling on icon alignment for buttons.

--- a/lib/components/ActionTrigger/ActionTrigger.module.scss
+++ b/lib/components/ActionTrigger/ActionTrigger.module.scss
@@ -5,7 +5,7 @@
 $line-height: 4.5*$grid-size;
 
 .action-trigger-container {
-    @include md-box(inline-block, relative, ellipsis);
+    @include md-box(flex, relative, ellipsis);
     font-family: $font-family-default;
     font-size: $icon-size-xsmall;
     line-height: $line-height;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "6.3.1",
+    "version": "6.3.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "6.3.1",
+    "version": "6.3.2",
     "description": "Azure IoT UX Fluent Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",


### PR DESCRIPTION
There was an error with the previous commit that the rightIcon on the actionTriggerButton would appear below the other content. This PR fixes that by showing it in the right position.