### PR TITLE
Fix alignment of items inside button and action trigger button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v6.3.3
+### Fixed
+- Fix alignment of items inside action trigger button and buttons.
+
 ## v6.3.2
 ### Fixed
 - Fix styling on action trigger button right icon.

--- a/lib/common/_mixins.scss
+++ b/lib/common/_mixins.scss
@@ -69,6 +69,14 @@
     } @else if $option == 'flex-row' {
         display: flex;
         flex-direction: row;
+    } @else if $option == 'inline-flex' {
+        display: inline-flex;
+    } @else if $option == 'inline-flex-column' {
+        display: inline-flex;
+        flex-direction: column;
+    } @else if $option == 'inline-flex-row' {
+        display: inline-flex;
+        flex-direction: row;
     } @else if $option == 'display-none' {
         display: none;
     }

--- a/lib/components/ActionTrigger/ActionTrigger.module.scss
+++ b/lib/components/ActionTrigger/ActionTrigger.module.scss
@@ -54,7 +54,6 @@ $line-height: 4.5*$grid-size;
         vertical-align: top;
         font-size: $font-size-default;
         margin-left: 2*$grid-size;
-        line-height: 100%;
 
         max-width: 50*$grid-size;
         overflow: hidden;

--- a/lib/components/Button/Button.module.scss
+++ b/lib/components/Button/Button.module.scss
@@ -7,10 +7,12 @@ $line-height: 8*$grid-size;
 $outline-focus-border-width: 1px;
 
 :global(.btn-primary), .method-btn-primary, :global(.btn-danger), .method-btn-danger, :global(.btn), .method-btn {
-    @include md-box(inline-block, relative);
+    @include md-box(inline-flex-row, relative);
     font-family: $font-family-default;
     font-size: $font-size-default;
     line-height: $line-height;
+    justify-content: center;
+    align-items: center;
 
     height: 8*$grid-size;
     padding-left: 5*$grid-size;
@@ -133,9 +135,4 @@ $outline-focus-border-width: 1px;
             background-color: themed('color-bg-btn-danger-disabled');
         }
     }
- }
-
- .label {
-     line-height: 100%;
-     vertical-align: text-top;
  }

--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -75,9 +75,7 @@ export const Button: React.StatelessComponent<ButtonProps> = (props: ButtonProps
             attr={props.attr.container}
         >
             {icon}
-            <span className={css('label')}>
-                {props.children}
-            </span>
+            {props.children}
         </ButtonProxy>
     );
 };

--- a/lib/components/Icon/Icon.module.scss
+++ b/lib/components/Icon/Icon.module.scss
@@ -9,6 +9,8 @@
     font-weight: normal;
     font-family: $font-family-default;
     display: flex;
+    align-items: center;
+    justify-content: center;
     
     &:before {
         @include md-box(inline-block, relative);

--- a/lib/components/Icon/Icon.module.scss
+++ b/lib/components/Icon/Icon.module.scss
@@ -8,7 +8,7 @@
     font-style: normal;
     font-weight: normal;
     font-family: $font-family-default;
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
     

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "6.3.2",
+    "version": "6.3.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "6.3.2",
+    "version": "6.3.3",
     "description": "Azure IoT UX Fluent Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",


### PR DESCRIPTION
The alignment of some instances of button and actionTiggerButton was off because of the changes of the previous release. This PR fixes those by leveraging flex in the button.

They should look like this now:

![buttons fix](https://user-images.githubusercontent.com/2132567/61656073-bf77e400-ac74-11e9-8f6c-56ace986be36.PNG)
