### PR TITLE
Fix DatePicker + DateTimeField to return null and set value to empty when the value is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v6.3.4
+### Fixed
+- Fix DatePicker + DateTimeField to return null and set value to empty when the value is removed
+
 ## v6.3.3
 ### Fixed
 - Fix alignment of items inside action trigger button and buttons.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v6.3.4
 ### Fixed
-- Fix DatePicker + DateTimeField to return null and set value to empty when the value is removed
+- Fix DatePicker + DateTimeField to return empty string and set value to empty when the value is removed
 
 ## v6.3.3
 ### Fixed

--- a/lib/components/DateTime/DatePicker.tsx
+++ b/lib/components/DateTime/DatePicker.tsx
@@ -330,7 +330,7 @@ export class DatePicker extends React.Component<DatePickerProps, Partial<DatePic
 
                 this.props.onChange(dateValue.dateObject.toJSON());
             } else {
-                this.props.onChange('invalid');
+                this.props.onChange(newValue === '' ? newValue : 'invalid');
                 this.setState({value: newValue});
             }
         }

--- a/lib/components/DateTime/DateTimeField.tsx
+++ b/lib/components/DateTime/DateTimeField.tsx
@@ -237,6 +237,10 @@ export class DateTimeField extends React.Component<DateTimeFieldProps, Partial<D
     }
 
     onChange = (newDate: string | Date, newTime: string | Date): Date => {
+        if (newDate === '') {
+            this.props.onChange(null);
+            return null;
+        }
         if (newDate === 'invalid' || newTime === 'invalid' || !newDate || !newTime) {
             this.props.onChange('invalid');
             return null;

--- a/lib/components/DateTime/DateTimeField.tsx
+++ b/lib/components/DateTime/DateTimeField.tsx
@@ -238,7 +238,7 @@ export class DateTimeField extends React.Component<DateTimeFieldProps, Partial<D
 
     onChange = (newDate: string | Date, newTime: string | Date): Date => {
         if (newDate === '') {
-            this.props.onChange(null);
+            this.props.onChange(newDate);
             return null;
         }
         if (newDate === 'invalid' || newTime === 'invalid' || !newDate || !newTime) {

--- a/lib/components/Masthead/Masthead.tsx
+++ b/lib/components/Masthead/Masthead.tsx
@@ -67,7 +67,7 @@ export interface MastheadProperties {
         attr?: InlinePopup.Attributes;
     };
     toolbarItems?: Array<MastheadToolbarItem>;
-    user?: MastheadUserItem;
+    user?: React.ReactNode;
 }
 
 export class Masthead extends React.PureComponent<MastheadProperties> {
@@ -175,7 +175,7 @@ export class Masthead extends React.PureComponent<MastheadProperties> {
                                 </InlinePopup.Container>
                             </li>
                         }
-                        {user && <li key='user-menu' className={cx('user-menu-item')}>
+                        {/* {user && <li key='user-menu' className={cx('user-menu-item')}>
                             <InlinePopup.Container
                                 expanded={user.menuExpanded}
                                 onClick={user.onMenuClick}
@@ -208,7 +208,7 @@ export class Masthead extends React.PureComponent<MastheadProperties> {
                                 </InlinePopup.Panel>
                             </InlinePopup.Container>
                         </li>
-                        }
+                        } */}
                     </ul >
                 </Attr.div >
             </Attr.div >

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "6.3.3",
+    "version": "6.3.4",
     "description": "Azure IoT UX Fluent Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",


### PR DESCRIPTION
When we remove the value entirely from the date field, the value being returned in 'invalid' which in a sense breaks the validation as it is not a date expected. Adding a fix to return the value as null in order to let validation succeed as a empty string in the date field is essentially right.