### PR TITLE
Use forwardingRef for fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v7.0.0
+### Changed
+- Add forwarding ref to form fields
+
 ## v6.3.5
 ### Changed
 - Updated the global nav icon to be the hamburger icon and always have it aligned to the left.

--- a/lib/Common.ts
+++ b/lib/Common.ts
@@ -329,6 +329,21 @@ export interface GridColumn<T> {
     width?: number;
 }
 
+const setRef = <T>(ref: React.Ref<T>, value: T) => {
+    if (typeof ref === 'function') {
+        ref(value);
+    } else if (ref != null) {
+        (ref as any).current = value;
+    }
+};
+
+export const mergeRefs = <T>(ref1: React.Ref<T>, ref2: React.Ref<T>) => {
+    return (e: T) => {
+        ref1 && setRef(ref1, e);
+        ref2 && setRef(ref2, e);
+    };
+};
+
 export const autoFocusRef = (e: HTMLElement) => {
     if (e) {
         e.focus();

--- a/lib/components/Field/CheckboxField.tsx
+++ b/lib/components/Field/CheckboxField.tsx
@@ -57,7 +57,8 @@ export interface CheckboxFieldProps extends React.Props<CheckboxFieldType> {
  *
  * @param props: Object fulfilling `CheckboxFieldProps` interface
  */
-export const CheckboxField: React.StatelessComponent<CheckboxFieldProps> = (props: CheckboxFieldProps) => {const tooltipId = (!!props.tooltip) ? `${props.name}-tt` : undefined;
+export const CheckboxField: React.StatelessComponent<CheckboxFieldProps> = React.forwardRef((props: CheckboxFieldProps, ref: React.RefObject<HTMLInputElement>) => {
+    const tooltipId = (!!props.tooltip) ? `${props.name}-tt` : undefined;
     const checkboxAttr: CheckboxInputAttributes = {
         container: props.attr.container,
         input: Object.assign({
@@ -108,11 +109,12 @@ export const CheckboxField: React.StatelessComponent<CheckboxFieldProps> = (prop
                     autoFocus={props.autoFocus}
                     required={props.required}
                     attr={checkboxAttr}
+                    ref={ref}
                 />
             </div>
         </FormField>
     );
-};
+});
 
 CheckboxField.defaultProps = {
     name: undefined,

--- a/lib/components/Field/ComboField.tsx
+++ b/lib/components/Field/ComboField.tsx
@@ -146,7 +146,7 @@ export interface ComboFieldProps extends React.Props<ComboFieldType> {
  *
  * @param props: Object fulfilling `ComboFieldProps` interface
  */
-export const ComboField: React.StatelessComponent<ComboFieldProps> = (props: ComboFieldProps) => {
+export const ComboField: React.StatelessComponent<ComboFieldProps> = React.forwardRef((props: ComboFieldProps, ref: React.RefObject<HTMLInputElement>) => {
     const tooltipId = (!!props.tooltip) ? `${props.name}-tt` : undefined;
     const comboAttr: ComboInputAttributes = {
         container: props.attr.container,
@@ -204,11 +204,12 @@ export const ComboField: React.StatelessComponent<ComboFieldProps> = (props: Com
                     showLabel={props.showLabel}
                     required={props.required}
                     attr={comboAttr}
+                    ref={ref}
                 />
             </div>
         </FormField>
     );
-};
+});
 
 ComboField.defaultProps = {
     name: undefined,

--- a/lib/components/Field/NumberField.tsx
+++ b/lib/components/Field/NumberField.tsx
@@ -63,7 +63,7 @@ export interface NumberFieldProps extends React.Props<NumberFieldType> {
  *
  * @param props Control properties (defined in `NumberFieldProps` interface)
  */
-export const NumberField: React.StatelessComponent<NumberFieldProps> = (props: NumberFieldProps) => {
+export const NumberField: React.StatelessComponent<NumberFieldProps> = React.forwardRef((props: NumberFieldProps, ref: React.RefObject<HTMLInputElement>) => {
     const tooltipId = (!!props.tooltip) ? `${props.name}-tt` : undefined;
     const numberAttr: TextInputAttributes = {
         container: props.attr.container,
@@ -119,10 +119,11 @@ export const NumberField: React.StatelessComponent<NumberFieldProps> = (props: N
                 max={props.max}
                 required={props.required}
                 attr={numberAttr}
+                ref={ref}
             />
         </FormField>
     );
-};
+});
 
 NumberField.defaultProps = {
     name: undefined,

--- a/lib/components/Field/SelectField.tsx
+++ b/lib/components/Field/SelectField.tsx
@@ -67,7 +67,7 @@ export interface SelectFieldProps extends React.Props<SelectFieldType> {
  *
  * @param props: Object fulfilling `SelectFieldProps` interface
  */
-export const SelectField: React.StatelessComponent<SelectFieldProps> = (props: SelectFieldProps) => {
+export const SelectField: React.StatelessComponent<SelectFieldProps> = React.forwardRef((props: SelectFieldProps, ref: React.RefObject<HTMLSelectElement>) => {
     const tooltipId = (!!props.tooltip) ? `${props.name}-tt` : undefined;
     const selectAttr: SelectInputAttributes = {
         container: props.attr.container,
@@ -116,10 +116,11 @@ export const SelectField: React.StatelessComponent<SelectFieldProps> = (props: S
                 autoFocus={props.autoFocus}
                 required={props.required}
                 attr={selectAttr}
+                ref={ref}
             />
         </FormField>
     );
-};
+});
 
 SelectField.defaultProps = {
     name: undefined,

--- a/lib/components/Field/TextAreaField.tsx
+++ b/lib/components/Field/TextAreaField.tsx
@@ -54,7 +54,7 @@ export interface TextAreaFieldProps extends React.Props<TextAreaFieldType> {
  *
  * @param props Control properties (defined in `TextAreaFieldProps` interface)
  */
-export const TextAreaField: React.StatelessComponent<TextAreaFieldProps> = (props: TextAreaFieldProps) => {
+export const TextAreaField: React.StatelessComponent<TextAreaFieldProps> = React.forwardRef((props: TextAreaFieldProps, ref: React.RefObject<HTMLTextAreaElement>) => {
     const tooltipId = (!!props.tooltip) ? `${props.name}-tt` : undefined;
     const textAreaAttr: TextAreaAttributes = {
         container: props.attr.container,
@@ -102,10 +102,11 @@ export const TextAreaField: React.StatelessComponent<TextAreaFieldProps> = (prop
                 autoFocus={props.autoFocus}
                 required={props.required}
                 attr={textAreaAttr}
+                ref={ref}
             />
         </FormField>
     );
-};
+});
 
 TextAreaField.defaultProps = {
     name: undefined,

--- a/lib/components/Field/TextField.tsx
+++ b/lib/components/Field/TextField.tsx
@@ -68,7 +68,7 @@ export interface TextFieldProps extends React.Props<TextFieldType> {
  *
  * @param props Control properties (defined in `TextFieldProps` interface)
  */
-export const TextField: React.StatelessComponent<TextFieldProps> = (props: TextFieldProps) => {
+export const TextField: React.StatelessComponent<TextFieldProps> = React.forwardRef((props: TextFieldProps, ref: React.RefObject<HTMLInputElement>) => {
     const tooltipId = (!!props.tooltip) ? `${props.name}-tt` : undefined;
     const errorId = `${props.name}-error`;
     let describedby = errorId;
@@ -131,10 +131,11 @@ export const TextField: React.StatelessComponent<TextFieldProps> = (props: TextF
                 autoFocus={props.autoFocus}
                 required={props.required}
                 attr={textAttr}
+                ref={ref}
             />
         </FormField>
     );
-};
+});
 
 TextField.defaultProps = {
     name: undefined,

--- a/lib/components/Field/ToggleField.tsx
+++ b/lib/components/Field/ToggleField.tsx
@@ -54,7 +54,7 @@ export interface ToggleFieldProps extends React.Props<ToggleFieldType> {
  *
  * @param props: Object fulfilling `ToggleFieldProps` interface
  */
-export const ToggleField: React.StatelessComponent<ToggleFieldProps> = (props: ToggleFieldProps) => {
+export const ToggleField: React.StatelessComponent<ToggleFieldProps> = React.forwardRef((props: ToggleFieldProps, ref: React.RefObject<HTMLButtonElement>) => {
     const tooltipId = (!!props.tooltip) ? `${props.name}-tt` : undefined;
     const toggleAttr: ToggleAttributes = {
         container: props.attr.container,
@@ -102,10 +102,11 @@ export const ToggleField: React.StatelessComponent<ToggleFieldProps> = (props: T
                 className={props.inputClassName}
                 autoFocus={props.autoFocus}
                 attr={toggleAttr}
+                ref={ref}
             />
         </FormField>
     );
-};
+});
 
 ToggleField.defaultProps = {
     name: undefined,

--- a/lib/components/Input/CheckboxInput.tsx
+++ b/lib/components/Input/CheckboxInput.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as classNames from 'classnames/bind';
 import styled, { ThemeProps, ThemeConsumer } from 'styled-components';
-import {MethodNode, autoFocusRef} from '../../Common';
+import {MethodNode, autoFocusRef, mergeRefs} from '../../Common';
 import {DivProps, LabelProps, SpanProps, InputProps, Elements as Attr} from '../../Attributes';
 import {Icon, IconSize, IconAttributes} from '../Icon';
 import {ShellTheme} from '../Shell';
@@ -68,7 +68,7 @@ const StyledActiveCheckboxButton = styled(Attr.span)`
  *
  * @param props Control properties (defined in `CheckboxInputProps` interface)
  */
-export const CheckboxInput: React.StatelessComponent<CheckboxInputProps> = (props: CheckboxInputProps) => {
+export const CheckboxInput: React.StatelessComponent<CheckboxInputProps> = React.forwardRef((props: CheckboxInputProps, ref: React.Ref<HTMLInputElement>) => {
     const containerClass = css('checkbox-container', {
         'columns': props.columns,
         'disabled': props.disabled,
@@ -107,7 +107,7 @@ export const CheckboxInput: React.StatelessComponent<CheckboxInputProps> = (prop
                     required={props.required}
                     onChange={onChange}
                     autoFocus={props.autoFocus}
-                    methodRef={props.autoFocus && autoFocusRef}
+                    methodRef={mergeRefs(props.autoFocus && autoFocusRef, ref)}
                     attr={props.attr.input}
                 />
                 <CheckboxInputProxy
@@ -138,7 +138,7 @@ export const CheckboxInput: React.StatelessComponent<CheckboxInputProps> = (prop
             </Attr.label>
         </Attr.div>
     );
-};
+});
 
 function stopPropagation(e: React.MouseEvent<HTMLElement>) {
     // HACK! If we don't add this click event handler to the label, React never

--- a/lib/components/Input/ComboInput.tsx
+++ b/lib/components/Input/ComboInput.tsx
@@ -3,10 +3,8 @@ import * as classNames from 'classnames/bind';
 import { DivProps, ButtonProps, SpanProps, InputProps, Elements as Attr, OptionAttr, mergeAttributes, mergeAttributeObjects } from '../../Attributes';
 import { Icon, IconSize } from '../Icon';
 import { Dropdown, DropdownAttributes } from '../Dropdown';
-import { MethodNode, FormOption, keyCode, hasClassName, autoFocusRef } from '../../Common';
+import { MethodNode, FormOption, keyCode, hasClassName, autoFocusRef, mergeRefs } from '../../Common';
 const css = classNames.bind(require('./ComboInput.module.scss'));
-
-export interface ComboInputType { }
 
 export interface ComboInputAttributes extends DropdownAttributes {
     textbox?: DivProps;
@@ -16,7 +14,7 @@ export interface ComboInputAttributes extends DropdownAttributes {
     option?: ButtonProps;
 }
 
-export interface ComboInputProps extends React.Props<ComboInputType> {
+export interface ComboInputProps {
     /** HTML form element name */
     name: string;
     /** Current value of HTML input element */
@@ -135,6 +133,10 @@ const defaultSelect = (newValue: string, option: string) => option === newValue;
 
 const defaultLabel = (newValue: string, option: FormOption) => option.label;
 
+interface ComboInputComponentProps extends ComboInputProps {
+    innerRef: React.Ref<HTMLInputElement>;
+}
+
 /**
  * Low level combo input control
  *
@@ -160,7 +162,7 @@ const defaultLabel = (newValue: string, option: FormOption) => option.label;
  *
  * (Use the `ComboField` control for forms with standard styling)
  */
-export class ComboInput extends React.Component<ComboInputProps, Partial<ComboInputState>> {
+class ComboInputComponent extends React.Component<ComboInputComponentProps, Partial<ComboInputState>> {
     static defaultProps = {
         optionMap: defaultMap,
         optionLabel: defaultLabel,
@@ -183,7 +185,7 @@ export class ComboInput extends React.Component<ComboInputProps, Partial<ComboIn
     private optionElements: { [value: string]: HTMLSpanElement };
     private currentOption: string;
 
-    constructor(props: ComboInputProps) {
+    constructor(props: ComboInputComponentProps) {
         super(props);
 
         this.state = {
@@ -502,7 +504,7 @@ export class ComboInput extends React.Component<ComboInputProps, Partial<ComboIn
                         required={this.props.required}
                         disabled={this.props.disabled}
                         readOnly={this.props.readOnly}
-                        methodRef={this.inputRef}
+                        methodRef={mergeRefs(this.inputRef, this.props.innerRef)}
                         autoFocus={this.props.autoFocus}
                         attr={this.props.attr.input}
                     />
@@ -516,5 +518,8 @@ export class ComboInput extends React.Component<ComboInputProps, Partial<ComboIn
         );
     }
 }
+
+export const ComboInput = React.forwardRef((props: ComboInputProps, ref: React.Ref<HTMLInputElement>) => 
+    <ComboInputComponent innerRef={ref} {...props} />);
 
 export default ComboInput;

--- a/lib/components/Input/NumberInput.tsx
+++ b/lib/components/Input/NumberInput.tsx
@@ -8,11 +8,9 @@ import { describe, it } from 'mocha';
 
 const css = classNames.bind(require('./TextInput.module.scss'));
 
-export interface NumberInputType { }
-
 const invalidNumber = 'invalid';
 
-export interface NumberInputProps extends React.Props<NumberInputType> {
+export interface NumberInputProps {
     /** HTML form element name */
     name: string;
     /** Current value of HTML input element */
@@ -56,12 +54,16 @@ export interface NumberInputState {
     paste?: boolean;
 }
 
+interface NumberInputComponentProps extends NumberInputProps {
+    innerRef: React.Ref<HTMLInputElement>;
+}
+
 /**
  * Low level text input control
  *
  * (Use the `TextField` control instead when making a form with standard styling)
  */
-export class NumberInput extends React.Component<NumberInputProps, NumberInputState> {
+class NumberInputComponent extends React.Component<NumberInputComponentProps, NumberInputState> {
     static defaultProps = {
         name: undefined,
         initialValue: '',
@@ -80,7 +82,7 @@ export class NumberInput extends React.Component<NumberInputProps, NumberInputSt
 
     private paste: boolean;
 
-    constructor(props: NumberInputProps) {
+    constructor(props: NumberInputComponentProps) {
         super(props);
 
         this.paste = false;
@@ -267,9 +269,13 @@ export class NumberInput extends React.Component<NumberInputProps, NumberInputSt
                 onChange={this.onChange}
                 required={this.props.required}
                 attr={attr}
+                ref={this.props.innerRef}
             />
         );
     }
 }
+
+export const NumberInput = React.forwardRef((props: NumberInputProps, ref: React.Ref<HTMLInputElement>) => 
+    <NumberInputComponent innerRef={ref} {...props} />);
 
 export default NumberInput;

--- a/lib/components/Input/SelectInput.tsx
+++ b/lib/components/Input/SelectInput.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as classNames from 'classnames/bind';
 import {DivProps, SpanProps, SelectProps, OptionProps, Elements as Attr, OptionAttr, mergeAttributes} from '../../Attributes';
- import {FormOption, autoFocusRef} from '../../Common';
+ import {FormOption, autoFocusRef, mergeRefs} from '../../Common';
 const css = classNames.bind(require('./SelectInput.module.scss'));
 
 export interface SelectInputType {}
@@ -66,7 +66,7 @@ export interface SelectInputProps extends React.Props<SelectInputType> {
  *
  * @param props Control properties (defined in `SelectInputProps` interface)
  */
-export const SelectInput: React.StatelessComponent<SelectInputProps> = (props: SelectInputProps) => {
+export const SelectInput: React.StatelessComponent<SelectInputProps> = React.forwardRef((props: SelectInputProps, ref: React.Ref<HTMLSelectElement>) => {
     const containerClass = css('combo-container', props.className);
     const comboClass = css(
         'combo', {'error': props.error}
@@ -109,7 +109,7 @@ export const SelectInput: React.StatelessComponent<SelectInputProps> = (props: S
                 onChange={onChange}
                 disabled={props.disabled}
                 autoFocus={props.autoFocus}
-                methodRef={props.autoFocus && autoFocusRef}
+                methodRef={mergeRefs(props.autoFocus && autoFocusRef, ref)}
                 required={props.required}
                 attr={props.attr.select}
             >
@@ -118,7 +118,7 @@ export const SelectInput: React.StatelessComponent<SelectInputProps> = (props: S
             <Attr.span className={arrowClassName} attr={props.attr.chevron}/>
         </Attr.div>
     );
-};
+});
 
 SelectInput.defaultProps = {
     name: undefined,

--- a/lib/components/Input/TextArea.tsx
+++ b/lib/components/Input/TextArea.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import * as classNames from 'classnames/bind';
 import {DivProps, SpanProps, PreProps, TextAreaProps, Elements as Attr} from '../../Attributes';
-import {MethodNode, autoFocusRef} from '../../Common';
+import {MethodNode, autoFocusRef, mergeRefs} from '../../Common';
 const css = classNames.bind(require('./TextArea.module.scss'));
-
-export interface TextAreaType {}
 
 export interface TextAreaAttributes {
     container?: DivProps;
@@ -12,7 +10,7 @@ export interface TextAreaAttributes {
     pre?: PreProps;
 }
 
-export interface TextAreaProps extends React.Props<TextAreaType> {
+export interface TextAreaProps {
     /** HTML form element name */
     name: string;
     /** Current value of HTML input element */
@@ -45,12 +43,16 @@ export interface TextAreaProps extends React.Props<TextAreaType> {
 export interface TextAreaState {
 }
 
+interface TextAreaComponentProps extends TextAreaProps {
+    innerRef: React.Ref<HTMLTextAreaElement>;
+}
+
 /**
  * Low level text input control
  *
  * (Use the `TextField` control instead when making a form with standard styling)
  */
-export class TextArea extends React.Component<TextAreaProps, TextAreaState> {
+class TextAreaComponent extends React.Component<TextAreaComponentProps, TextAreaState> {
     static defaultProps = {
         autogrow: true,
         error: false,
@@ -67,11 +69,11 @@ export class TextArea extends React.Component<TextAreaProps, TextAreaState> {
 
     private ghost: HTMLPreElement;
 
-    constructor(props: TextAreaProps) {
+    constructor(props: TextAreaComponentProps) {
         super(props);
     }
 
-    componentDidUpdate(prevProps: TextAreaProps, prevState: TextAreaState) {
+    componentDidUpdate(prevProps: TextAreaComponentProps, prevState: TextAreaState) {
         const height = this.ghost && this.ghost.offsetHeight;
         if (this.props.autogrow && prevProps.value !== this.props.value && height > 52) {
             this.textarea.style.height = `${height}px`;
@@ -94,7 +96,7 @@ export class TextArea extends React.Component<TextAreaProps, TextAreaState> {
                     disabled={this.props.disabled}
                     readOnly={this.props.readOnly}
                     placeholder={this.props.placeholder}
-                    methodRef={this.bindTextArea}
+                    methodRef={mergeRefs(this.bindTextArea, this.props.innerRef)}
                     autoFocus={this.props.autoFocus}
                     required={this.props.required}
                     attr={this.props.attr.textarea}
@@ -121,5 +123,8 @@ export class TextArea extends React.Component<TextAreaProps, TextAreaState> {
 
     private bindGhost = element => this.ghost = element;
 }
+
+export const TextArea = React.forwardRef((props: TextAreaProps, ref: React.Ref<HTMLTextAreaElement>) => 
+    <TextAreaComponent innerRef={ref} {...props} />);
 
 export default TextArea;

--- a/lib/components/Input/TextInput.tsx
+++ b/lib/components/Input/TextInput.tsx
@@ -2,14 +2,11 @@ import * as React from 'react';
 import * as classNames from 'classnames/bind';
 import {DivProps, ButtonProps, InputProps, Elements as Attr} from '../../Attributes';
 import {Icon, IconSize} from '../Icon';
-import {MethodNode, autoFocusRef} from '../../Common';
+import {MethodNode, autoFocusRef, mergeRefs} from '../../Common';
 const css = classNames.bind(require('./TextInput.module.scss'));
 
 export const prefixClassName = css('prefix-addon');
 export const postfixClassName = css('postfix-addon');
-
-export interface TextInputType {}
-
 
 export interface TextInputAttributes {
     container?: DivProps;
@@ -20,7 +17,7 @@ export interface TextInputAttributes {
     clearButton?: ButtonProps;
 }
 
-export interface TextInputProps extends React.Props<TextInputType> {
+export interface TextInputProps {
     /** HTML form element name */
     name: string;
     /** Current value of HTML input element */
@@ -63,14 +60,18 @@ export interface TextInputProps extends React.Props<TextInputType> {
     attr?: TextInputAttributes;
 }
 
+interface TextInputComponentProps extends TextInputProps {
+    innerRef: React.Ref<HTMLInputElement>;
+}
+
 /**
  * Low level text input control
  *
  * (Use the `TextField` control instead when making a form with standard styling)
  */
-export class TextInput extends React.PureComponent<TextInputProps> {
+class TextInputComponent extends React.PureComponent<TextInputComponentProps> {
 
-    public static defaultProps: Partial<TextInputProps> = {
+    public static defaultProps: Partial<TextInputComponentProps> = {
         name: undefined,
         value: undefined,
         onChange: undefined,
@@ -85,7 +86,7 @@ export class TextInput extends React.PureComponent<TextInputProps> {
         }
     };
 
-    constructor(props: TextInputProps) {
+    constructor(props: TextInputComponentProps) {
         super(props);
         this.onChange = this.onChange.bind(this);
         this.onClear = this.onClear.bind(this);
@@ -160,7 +161,7 @@ export class TextInput extends React.PureComponent<TextInputProps> {
                         disabled={this.props.disabled}
                         readOnly={this.props.readOnly}
                         autoFocus={this.props.autoFocus}
-                        methodRef={this.props.autoFocus && autoFocusRef}
+                        methodRef={mergeRefs(this.props.autoFocus && autoFocusRef, this.props.innerRef)}
                         attr={this.props.attr.input}
                     />
                     {clearButton}
@@ -170,5 +171,8 @@ export class TextInput extends React.PureComponent<TextInputProps> {
         );
     }
 }
+
+export const TextInput = React.forwardRef((props: TextInputProps, ref: React.Ref<HTMLInputElement>) => 
+    <TextInputComponent innerRef={ref} {...props} />);
 
 export default TextInput;

--- a/lib/components/SearchInput/SearchInput.tsx
+++ b/lib/components/SearchInput/SearchInput.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as classNames from 'classnames/bind';
 import { Icon } from '../Icon';
-import TextInput, { TextInputType, TextInputAttributes } from '../Input/TextInput';
+import TextInput, { TextInputAttributes } from '../Input/TextInput';
 import { ActionTriggerButton } from '../ActionTrigger';
 const css = classNames.bind(require('./SearchInput.module.scss'));
 
@@ -10,7 +10,7 @@ export const postfixClassName = css('postfix-addon');
 
 
 
-export interface SearchInputProps extends React.Props<TextInputType> {
+export interface SearchInputProps {
     label: string;
     onSubmit: React.EventHandler<any>;
     onChange: (newValue: string) => void;

--- a/lib/components/Toggle/Toggle.tsx
+++ b/lib/components/Toggle/Toggle.tsx
@@ -3,7 +3,7 @@ import * as classNames from 'classnames/bind';
 import styled, { ThemeProps } from 'styled-components';
 
 import {DivProps, ButtonProps, Elements as Attr} from '../../Attributes';
-import {MethodNode, autoFocusRef} from '../../Common';
+import {MethodNode, autoFocusRef, mergeRefs} from '../../Common';
 import { ShellTheme } from '../Shell';
 
 const css = classNames.bind(require('./Toggle.module.scss'));
@@ -58,7 +58,7 @@ const StyledToggleOnSwitch = styled(Attr.div)`
  *
  * @param props Control properties (defined in `ToggleProps` interface)
  */
-export const Toggle: React.StatelessComponent<ToggleProps> = (props: ToggleProps) => {
+export const Toggle: React.StatelessComponent<ToggleProps> = React.forwardRef((props: ToggleProps, ref: React.Ref<HTMLButtonElement>) => {
     const containerClassName = css('toggle', {
         'toggle-on': props.on,
         'disabled': props.disabled
@@ -84,7 +84,7 @@ export const Toggle: React.StatelessComponent<ToggleProps> = (props: ToggleProps
                 tabIndex={tabIndex}
                 name={props.name}
                 autoFocus={props.autoFocus}
-                methodRef={props.autoFocus && autoFocusRef}
+                methodRef={mergeRefs(props.autoFocus && autoFocusRef, ref)}
                 // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_switch_role
                 // the switch role represents the states "on" and "off."
                 role='switch'
@@ -97,7 +97,7 @@ export const Toggle: React.StatelessComponent<ToggleProps> = (props: ToggleProps
             </Attr.div>
         </Attr.div>
     );
-};
+});
 
 Toggle.defaultProps = {
     name: undefined,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "6.3.5",
+    "version": "7.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "6.3.5",
+    "version": "7.0.0",
     "description": "Azure IoT UX Fluent Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",


### PR DESCRIPTION
Instead of relying in the `attr` API for refs, we should have our fields and inputs use ref forwarding to get the underlaying DOM elements.