### PR TITLE
Minor styling fixes

### DIFF
--- a/lib/components/Field/Field.module.scss
+++ b/lib/components/Field/Field.module.scss
@@ -74,7 +74,7 @@ $line-height: 5*$grid-size;
 }
 
 .field-error {
-    @include md-box(inline-block, ellipsis);
+    @include md-box(block, ellipsis);
     height: $form-error-height;
     width: 100%;
     color: var(--color-text-error);

--- a/lib/components/GalleryCard/GalleryCard.module.scss
+++ b/lib/components/GalleryCard/GalleryCard.module.scss
@@ -19,6 +19,7 @@ $card-fixed-content-height: $gallery-card-height - $gallery-card-background-heig
 
   display: inline-block; // this is a tile, not a normal <a> tag
   margin: 2.5 * $grid-size; // put some spacing between the tiles by default
+  cursor: pointer;
 
   &:not(:global(.disabled)) {
     &:global(.selected) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "7.0.0-alpha.32",
+    "version": "7.0.0-alpha.33",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "7.0.0-alpha.32",
+    "version": "7.0.0-alpha.33",
     "description": "Azure IoT UX Fluent Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",


### PR DESCRIPTION
1. Change FieldError's display from `inline-block` to `block` since it's not inline, and to avoid adding an extra 5px to the end of the FormField.
2. Add pointer:cursor to Link GalleryCard