### PR TITLE
fixing padding for masthead title

### DIFF
--- a/lib/components/Masthead/Masthead.module.scss
+++ b/lib/components/Masthead/Masthead.module.scss
@@ -95,7 +95,7 @@ $search-max-size: 100 * $grid-size;
     width: $masthead-branding-width;
     height: $layout-masthead-height;
     display: inline-block;
-    padding: 0px $gutter-normal;
+    padding: 0px $gutter-small;
     line-height: $layout-masthead-height;
     font-size: var(--font-size-h3);
     font-weight: bold;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "7.0.0-alpha.36",
+    "version": "7.0.0-alpha.37",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "7.0.0-alpha.37",
+    "version": "7.0.0-alpha.39",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "7.0.0-alpha.37",
+    "version": "7.0.0-alpha.39",
     "description": "Azure IoT UX Fluent Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "7.0.0-alpha.36",
+    "version": "7.0.0-alpha.37",
     "description": "Azure IoT UX Fluent Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",


### PR DESCRIPTION
The overall padding between masthead logo and masthead title should be 1rem according to design. Currently, it is greater than 1rem.