### PR TITLE
Fix deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 7.0.7
+### Changed
+- Change `data-active` attribute to be a boolean attribute (i.e., emit <foo data-active> instead of <foo data-active="true">)
+- Rename componentWillReceiveProps to (UNSAFE_componentWillReceiveProps)[https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html] to avoid deprecation warnings in React 16.11+
+
 ## 7.0.6
 ### Changed
 - Added data-test-active to active navigation item

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Changed
 - Change `data-active` attribute to be a boolean attribute (i.e., emit <foo data-active> instead of <foo data-active="true">)
 - Rename componentWillReceiveProps to (UNSAFE_componentWillReceiveProps)[https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html] to avoid deprecation warnings in React 16.11+
+### Fixed
+- Update handlebars version to fix vulnerability
 
 ## 7.0.6
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changed
 - Change `data-active` attribute to be a boolean attribute (i.e., emit \<foo data-active> instead of \<foo data-active="true">)
 - Rename componentWillReceiveProps to [UNSAFE_componentWillReceiveProps](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) to avoid deprecation warnings in React 16.11+
+- Add deprecation warnings for Date components because they're not fully localized/accessible. We should use the [Office Fabric control](https://developer.microsoft.com/en-us/fabric/#/controls/web/datepicker) instead.
 ### Fixed
 - Update handlebars version to fix vulnerability
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 7.0.7
 ### Changed
-- Change `data-active` attribute to be a boolean attribute (i.e., emit <foo data-active> instead of <foo data-active="true">)
-- Rename componentWillReceiveProps to (UNSAFE_componentWillReceiveProps)[https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html] to avoid deprecation warnings in React 16.11+
+- Change `data-active` attribute to be a boolean attribute (i.e., emit \<foo data-active> instead of \<foo data-active="true">)
+- Rename componentWillReceiveProps to [UNSAFE_componentWillReceiveProps](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) to avoid deprecation warnings in React 16.11+
 ### Fixed
 - Update handlebars version to fix vulnerability
 

--- a/lib/components/Balloon/Balloon.tsx
+++ b/lib/components/Balloon/Balloon.tsx
@@ -76,7 +76,7 @@ export class Balloon extends React.Component<BalloonProps, BalloonState> {
         };
     }
 
-    componentWillReceiveProps(newProps: BalloonProps) {
+    UNSAFE_componentWillReceiveProps(newProps: BalloonProps) {
         this.setState({
             visible: this.state.hovered || newProps.expanded,
         });

--- a/lib/components/DateTime/Calendar.tsx
+++ b/lib/components/DateTime/Calendar.tsx
@@ -60,6 +60,7 @@ export interface CalendarState {
  * Calendar control
  *
  * @param props Control properties (defined in `CalendarProps` interface)
+ * @deprecated This is not fully localized/accessible. Use https://developer.microsoft.com/en-us/fabric/#/controls/web/datepicker instead.
  */
 export class Calendar extends React.Component<CalendarProps, Partial<CalendarState>> {
     static defaultProps = {
@@ -119,7 +120,7 @@ export class Calendar extends React.Component<CalendarProps, Partial<CalendarSta
         this.setContainerRef = this.setContainerRef.bind(this);
     }
 
-    componentWillReceiveProps(newProps: CalendarProps) {
+    UNSAFE_componentWillReceiveProps(newProps: CalendarProps) {
         const date = this.state.currentDate.copy();
         let update = false;
         if (newProps.year !== this.props.year && newProps.year > 0) {

--- a/lib/components/DateTime/DateField.tsx
+++ b/lib/components/DateTime/DateField.tsx
@@ -72,6 +72,7 @@ export interface DateFieldProps extends React.Props<DateFieldType> {
  * High level form text field
  *
  * @param props Control properties (defined in `DateFieldProps` interface)
+ * @deprecated This is not fully localized/accessible. Use https://developer.microsoft.com/en-us/fabric/#/controls/web/datepicker instead.
  */
 export const DateField: React.StatelessComponent<DateFieldProps> = (props: DateFieldProps) => {
     const tooltipId = (!!props.tooltip) ? `${props.name}-tt` : undefined;

--- a/lib/components/DateTime/DatePicker.tsx
+++ b/lib/components/DateTime/DatePicker.tsx
@@ -91,6 +91,7 @@ export interface DatePickerState {
  * Low level date picker control
  *
  * (Use the `DateField` control instead when making a form with standard styling)
+ * @deprecated This is not fully localized/accessible. Use https://developer.microsoft.com/en-us/fabric/#/controls/web/datepicker instead.
  */
 export class DatePicker extends React.Component<DatePickerProps, Partial<DatePickerState>> {
     static defaultProps = {
@@ -207,7 +208,7 @@ export class DatePicker extends React.Component<DatePickerProps, Partial<DatePic
      *
      * @param newProps new DatePickerProps
      */
-    componentWillReceiveProps(newProps: DatePickerProps) {
+    UNSAFE_componentWillReceiveProps(newProps: DatePickerProps) {
         if ((this.props.initialValue !== newProps.initialValue || this.props.localTimezone !== newProps.localTimezone) && newProps.initialValue !== 'invalid') {
             const newState = this.getInitialState(newProps, this.input.value);
             this.setState({

--- a/lib/components/DateTime/DateTimeField.tsx
+++ b/lib/components/DateTime/DateTimeField.tsx
@@ -91,6 +91,7 @@ export interface DateTimeFieldState {
  * High level date time field
  *
  * @param props Control properties (defined in `DateTimeFieldProps` interface)
+ * @deprecated This is not fully localized/accessible. Use https://developer.microsoft.com/en-us/fabric/#/controls/web/datepicker instead.
  */
 export class DateTimeField extends React.Component<DateTimeFieldProps, Partial<DateTimeFieldState>> {
     static defaultProps = {
@@ -211,7 +212,7 @@ export class DateTimeField extends React.Component<DateTimeFieldProps, Partial<D
         };
     }
 
-    componentWillReceiveProps(newProps: DateTimeFieldProps) {
+    UNSAFE_componentWillReceiveProps(newProps: DateTimeFieldProps) {
         if (this.props.initialValue !== newProps.initialValue || this.props.localTimezone !== newProps.localTimezone) {
             this.setState(this.getInitialState(newProps));
         }

--- a/lib/components/DateTime/TimeInput.tsx
+++ b/lib/components/DateTime/TimeInput.tsx
@@ -170,7 +170,7 @@ export class TimeInput extends React.Component<TimeInputProps, TimeInputState> {
         return time;
     }
 
-    componentWillReceiveProps(newProps) {
+    UNSAFE_componentWillReceiveProps(newProps) {
         let newState: any = {};
         let update = false;
         let newHours = this.state.hours;

--- a/lib/components/Input/NumberInput.tsx
+++ b/lib/components/Input/NumberInput.tsx
@@ -226,7 +226,7 @@ export class NumberInput extends React.Component<NumberInputProps, NumberInputSt
         }
     }
 
-    componentWillReceiveProps(newProps: NumberInputProps) {
+    UNSAFE_componentWillReceiveProps(newProps: NumberInputProps) {
         if (this.props.initialValue !== newProps.initialValue) {
             this.setState(this.getInitialState(newProps.initialValue));
         }

--- a/lib/components/Navigation/Navigation.tsx
+++ b/lib/components/Navigation/Navigation.tsx
@@ -39,7 +39,7 @@ export function Navigation({ isExpanded, onClick, attr, children, farBottomChild
                 // Only take the first active link as active and set everything else to not active
                 if (item.className.includes('global-nav-item-active') && activeItemIndex === -1) {
                     activeItemIndex = i;
-                    item.setAttribute('data-active', 'true');
+                    item.setAttribute('data-active', ''); // set boolean attribute
                 } else {
                     item.removeAttribute('data-active');
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "7.0.6",
+    "version": "7.0.7",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5972,9 +5972,9 @@
             "dev": true
         },
         "handlebars": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-            "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.2.tgz",
+            "integrity": "sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==",
             "dev": true,
             "requires": {
                 "neo-async": "^2.6.0",
@@ -8812,7 +8812,7 @@
                 },
                 "find-up": {
                     "version": "3.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                     "dev": true,
                     "requires": {
@@ -8827,13 +8827,13 @@
                 },
                 "is-fullwidth-code-point": {
                     "version": "2.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                     "dev": true
                 },
                 "locate-path": {
                     "version": "3.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
                     "dev": true,
                     "requires": {
@@ -8862,7 +8862,7 @@
                 },
                 "p-locate": {
                     "version": "3.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
                     "dev": true,
                     "requires": {
@@ -8883,7 +8883,7 @@
                 },
                 "pkg-dir": {
                     "version": "3.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
                     "dev": true,
                     "requires": {
@@ -8927,7 +8927,7 @@
                 },
                 "which-module": {
                     "version": "2.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
                     "dev": true
                 },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "7.0.6",
+    "version": "7.0.7",
     "description": "Azure IoT UX Fluent Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",


### PR DESCRIPTION
### Changed
- Change `data-active` attribute to be a boolean attribute (i.e., emit \<foo data-active> instead of \<foo data-active="true">)
- Rename componentWillReceiveProps to [UNSAFE_componentWillReceiveProps](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html) to avoid deprecation warnings in React 16.11+
- Add deprecation warnings for Date components because they're not fully localized/accessible. We should use the [Office Fabric control](https://developer.microsoft.com/en-us/fabric/#/controls/web/datepicker) instead.
### Fixed
- Update handlebars version to fix vulnerability