### PR TITLE
Update masthead to center logo

### DIFF
--- a/lib/components/Masthead/Masthead.module.scss
+++ b/lib/components/Masthead/Masthead.module.scss
@@ -86,7 +86,8 @@ $search-max-size: 100 * $grid-size;
   }
 
   .masthead-logo {
-    height: 100%;
+    display: flex;
+    align-items: center;
     padding: $gutter-xxsmall 0 $gutter-xxsmall $gutter-xsmall;
 
     @include rtl {


### PR DESCRIPTION
Masthead logo was updated with one of the previous checkins and this css to center vertically the logo was missing.