### PR TITLE
Make screen readers announce balloon tooltips

### DIFF
--- a/lib/components/Balloon/Balloon.tsx
+++ b/lib/components/Balloon/Balloon.tsx
@@ -7,7 +7,6 @@ const css = classNames.bind(require('./Balloon.module.scss'));
 
 export interface BalloonAttributes {
     container?: SpanProps;
-    balloonContainer?: DivProps;
     balloon?: SpanProps;
     balloonContent?: SpanProps;
 }
@@ -137,7 +136,6 @@ export class Balloon extends React.Component<BalloonProps, BalloonState> {
                 dropdownSeparation={1}
                 attr={{
                     host: this.props.attr.container,
-                    dropdownContainer: this.props.attr.balloonContainer,
                     dropdown: mergeAttributes(
                         this.props.attr.balloon,
                         {className: balloonClassName}

--- a/lib/components/DateTime/DateField.tsx
+++ b/lib/components/DateTime/DateField.tsx
@@ -75,12 +75,8 @@ export interface DateFieldProps extends React.Props<DateFieldType> {
  * @deprecated This is not fully localized/accessible. Use https://developer.microsoft.com/en-us/fabric/#/controls/web/datepicker instead.
  */
 export const DateField: React.StatelessComponent<DateFieldProps> = (props: DateFieldProps) => {
-    const tooltipId = (!!props.tooltip) ? `${props.name}-tt` : undefined;
     const errorId = `${props.name}-error`;
     let describedby = errorId;
-    if (tooltipId) {
-        describedby += ' ' + tooltipId;
-    }
     const dateAttr: DatePickerAttributes = {
         input: Object.assign({
             'aria-label': props.label,
@@ -91,13 +87,7 @@ export const DateField: React.StatelessComponent<DateFieldProps> = (props: DateF
         calendar: props.attr.calendar
     };
     const fieldAttr: FormFieldAttributes = {
-        fieldLabel: Object.assign({
-            balloon: {
-                balloonContent: {
-                    id: tooltipId
-                }
-            }
-        }, props.attr.fieldLabel),
+        fieldLabel: props.attr.fieldLabel,
         fieldError: Object.assign({
             id: errorId
         }, props.attr.fieldError),

--- a/lib/components/DateTime/DateTimeField.tsx
+++ b/lib/components/DateTime/DateTimeField.tsx
@@ -302,12 +302,8 @@ export class DateTimeField extends React.Component<DateTimeFieldProps, Partial<D
     }
 
     render() {
-        const tooltipId = (!!this.props.tooltip) ? `${this.props.name}-tt` : undefined;
         const errorId = `${this.props.name}-error`;
         let describedby = errorId;
-        if (tooltipId) {
-            describedby += ' ' + tooltipId;
-        }
         const dateAttr: DatePickerAttributes = {
             input: Object.assign({
                 'aria-describedby': describedby
@@ -336,13 +332,7 @@ export class DateTimeField extends React.Component<DateTimeFieldProps, Partial<D
             ...(this.props.attr.timeInput && this.props.attr.timeInput)
         };
         const fieldAttr: FormFieldAttributes = {
-            fieldLabel: Object.assign({
-                balloon: {
-                    balloon: {
-                        id: tooltipId
-                    }
-                }
-            }, this.props.attr.fieldLabel),
+            fieldLabel: this.props.attr.fieldLabel,
             fieldError: Object.assign({
                 id: errorId
             }, this.props.attr.fieldError),

--- a/lib/components/Dropdown/Dropdown.module.scss
+++ b/lib/components/Dropdown/Dropdown.module.scss
@@ -167,10 +167,6 @@ $arrow-size: 2*$grid-size;
     
     :global(.md-dropdown) {
         visibility: visible;
-        pointer-events: none;
-
-        &.interactive {
-            pointer-events: auto;
-        }
+        pointer-events: auto;
     }
 }

--- a/lib/components/Dropdown/Dropdown.tsx
+++ b/lib/components/Dropdown/Dropdown.tsx
@@ -25,7 +25,6 @@ export enum DropdownAlignment {
 
 export interface DropdownAttributes {
     host?: SpanProps;
-    dropdownContainer?: DivProps;
     dropdown?: SpanProps;
 }
 
@@ -98,7 +97,7 @@ export interface DropdownProps {
 export const Dropdown = React.memo(({ className, onMouseEnter, onMouseLeave, attr, dropdown, children, visible, outerEvents, onOuterEvent, positionHint, alignmentHint, showArrow, dropdownSeparation }: DropdownProps) => {
     const dropdownRef = React.useRef<HTMLSpanElement>();
     const hostRef = React.useRef<HTMLSpanElement>();
-    const containerRef = React.useRef<HTMLDivElement>();
+    const containerRef = React.useRef<HTMLDivElement>(document.querySelector('#md-dropdown-container'));
     
     const eventsConnected = React.useRef<boolean>(false);
 
@@ -349,7 +348,7 @@ export const Dropdown = React.memo(({ className, onMouseEnter, onMouseLeave, att
                 data-dropdown-visible='false'
                 attr={attr && attr.host}>
                 <Attr.span
-                    aria-hidden={interactive}
+                    aria-hidden={!visible}
                     className={css('md-dropdown', { interactive, 'with-arrow': showArrow })}
                     attr={attr && attr.dropdown}
                     methodRef={dropdownRef}>
@@ -357,14 +356,6 @@ export const Dropdown = React.memo(({ className, onMouseEnter, onMouseLeave, att
                 </Attr.span>
                 {children}
             </Attr.span>
-            {visible && ReactDOM.createPortal(
-                <Attr.div
-                    className={css('md-dropdown-container', { interactive })}
-                    methodRef={containerRef}
-                    attr={attr && attr.dropdownContainer}>
-                </Attr.div>,
-                document.querySelector('.shell')
-            )}
         </>
     );
 });

--- a/lib/components/Field/CheckboxField.tsx
+++ b/lib/components/Field/CheckboxField.tsx
@@ -55,12 +55,11 @@ export interface CheckboxFieldProps extends React.Props<CheckboxFieldType> {
  *
  * @param props: Object fulfilling `CheckboxFieldProps` interface
  */
-export const CheckboxField: React.StatelessComponent<CheckboxFieldProps> = (props: CheckboxFieldProps) => {const tooltipId = (!!props.tooltip) ? `${props.name}-tt` : undefined;
+export const CheckboxField: React.StatelessComponent<CheckboxFieldProps> = (props: CheckboxFieldProps) => {
     const checkboxAttr: CheckboxInputAttributes = {
         container: props.attr.container,
         input: Object.assign({
             'aria-label': props.label,
-            'aria-describedby': tooltipId
         }, props.attr.input),
         label: props.attr.label,
         text: props.attr.text,
@@ -70,13 +69,7 @@ export const CheckboxField: React.StatelessComponent<CheckboxFieldProps> = (prop
         border: props.attr.border,
     };
     const fieldAttr: FormFieldAttributes = {
-        fieldLabel: Object.assign({
-            balloon: {
-                balloonContent: {
-                    id: tooltipId
-                }
-            }
-        }, props.attr.fieldLabel),
+        fieldLabel: props.attr.fieldLabel,
         fieldError: props.attr.fieldError,
         fieldContent: props.attr.fieldContent,
         fieldContainer: props.attr.fieldContainer

--- a/lib/components/Field/ComboField.tsx
+++ b/lib/components/Field/ComboField.tsx
@@ -145,12 +145,10 @@ export interface ComboFieldProps extends React.Props<ComboFieldType> {
  * @param props: Object fulfilling `ComboFieldProps` interface
  */
 export const ComboField: React.StatelessComponent<ComboFieldProps> = (props: ComboFieldProps) => {
-    const tooltipId = (!!props.tooltip) ? `${props.name}-tt` : undefined;
     const comboAttr: ComboInputAttributes = {
         host: props.attr.host,
         input: Object.assign({
             'aria-label': props.label,
-            'aria-describedby': tooltipId
         }, props.attr.input),
         clearButton: props.attr.clearButton,
         textbox: props.attr.textbox,
@@ -159,13 +157,7 @@ export const ComboField: React.StatelessComponent<ComboFieldProps> = (props: Com
         option: props.attr.option,
     };
     const fieldAttr: FormFieldAttributes = {
-        fieldLabel: Object.assign({
-            balloon: {
-                balloonContent: {
-                    id: tooltipId
-                }
-            }
-        }, props.attr.fieldLabel),
+        fieldLabel: props.attr.fieldLabel,
         fieldError: props.attr.fieldError,
         fieldContent: props.attr.fieldContent,
         fieldContainer: props.attr.fieldContainer

--- a/lib/components/Field/FormLabel.tsx
+++ b/lib/components/Field/FormLabel.tsx
@@ -80,16 +80,7 @@ export const FormLabel: React.StatelessComponent<FormLabelProps> = (props: FormL
             expanded={props.balloonExpanded}
             positionHint={props.balloonPositionHint}
             alignmentHint={props.balloonAlignmentHint}
-            attr={mergeAttributeObjects(
-                props.attr.balloon,
-                {
-                balloonContainer: {
-                    role: 'tooltip',
-                    'aria-live': 'polite',
-                    'aria-atomic': 'true'
-                }},
-                ['container', 'balloonContainer', 'balloon', 'balloonContent']
-            )}
+            attr={props.attr.balloon}
         >
             <Icon
                 icon={props.icon}
@@ -137,7 +128,6 @@ FormLabel.defaultProps = {
         },
         balloon: {
             container: {},
-            balloonContainer: {},
             balloon: {},
         },
     }

--- a/lib/components/Field/NumberField.tsx
+++ b/lib/components/Field/NumberField.tsx
@@ -62,12 +62,10 @@ export interface NumberFieldProps extends React.Props<NumberFieldType> {
  * @param props Control properties (defined in `NumberFieldProps` interface)
  */
 export const NumberField: React.StatelessComponent<NumberFieldProps> = (props: NumberFieldProps) => {
-    const tooltipId = (!!props.tooltip) ? `${props.name}-tt` : undefined;
     const numberAttr: TextInputAttributes = {
         container: props.attr.container,
         input: Object.assign({
             'aria-label': props.label,
-            'aria-describedby': tooltipId
         }, props.attr.input),
         inputContainer: props.attr.inputContainer,
         prefix: props.attr.prefix,
@@ -75,13 +73,7 @@ export const NumberField: React.StatelessComponent<NumberFieldProps> = (props: N
         clearButton: props.attr.clearButton
     };
     const fieldAttr: FormFieldAttributes = {
-        fieldLabel: Object.assign({
-            balloon: {
-                balloonContent: {
-                    id: tooltipId
-                }
-            }
-        }, props.attr.fieldLabel),
+        fieldLabel: props.attr.fieldLabel,
         fieldError: props.attr.fieldError,
         fieldContent: props.attr.fieldContent,
         fieldContainer: props.attr.fieldContainer

--- a/lib/components/Field/RadioField.tsx
+++ b/lib/components/Field/RadioField.tsx
@@ -72,16 +72,8 @@ export const RadioField: React.StatelessComponent<RadioFieldProps> = (props: Rad
         props.onChange(props.options[index].value);
     };
 
-    const tooltipId = (!!props.tooltip) ? `${props.name}-tt` : undefined;
-
     const fieldAttr: FormFieldAttributes = {
-        fieldLabel: Object.assign({
-            balloon: {
-                balloonContent: {
-                    id: tooltipId
-                }
-            }
-        }, props.attr.fieldLabel),
+        fieldLabel: props.attr.fieldLabel,
         fieldError: props.attr.fieldError,
         fieldContent: props.attr.fieldContent,
         fieldContainer: props.attr.fieldContainer
@@ -93,7 +85,6 @@ export const RadioField: React.StatelessComponent<RadioFieldProps> = (props: Rad
             label: props.attr.label,
             input: Object.assign({
                 'aria-label': option.label,
-                'aria-describedby': tooltipId
             }, props.attr.input),
             radio: props.attr.radio,
             text: props.attr.text,

--- a/lib/components/Field/SelectField.tsx
+++ b/lib/components/Field/SelectField.tsx
@@ -66,25 +66,17 @@ export interface SelectFieldProps extends React.Props<SelectFieldType> {
  * @param props: Object fulfilling `SelectFieldProps` interface
  */
 export const SelectField: React.StatelessComponent<SelectFieldProps> = (props: SelectFieldProps) => {
-    const tooltipId = (!!props.tooltip) ? `${props.name}-tt` : undefined;
     const selectAttr: SelectInputAttributes = {
         container: props.attr.container,
         select: Object.assign({
             'aria-label': props.label,
-            'aria-describedby': tooltipId
         }, props.attr.select),
         option: props.attr.option,
         chevron: props.attr.chevron,
     };
 
     const fieldAttr: FormFieldAttributes = {
-        fieldLabel: Object.assign({
-            balloon: {
-                balloonContent: {
-                    id: tooltipId
-                }
-            }
-        }, props.attr.fieldLabel),
+        fieldLabel: props.attr.fieldLabel,
         fieldError: props.attr.fieldError,
         fieldContent: props.attr.fieldContent,
         fieldContainer: props.attr.fieldContainer

--- a/lib/components/Field/TextAreaField.tsx
+++ b/lib/components/Field/TextAreaField.tsx
@@ -56,23 +56,15 @@ export interface TextAreaFieldProps extends React.Props<TextAreaFieldType> {
  * @param props Control properties (defined in `TextAreaFieldProps` interface)
  */
 export const TextAreaField: React.StatelessComponent<TextAreaFieldProps> = (props: TextAreaFieldProps) => {
-    const tooltipId = (!!props.tooltip) ? `${props.name}-tt` : undefined;
     const textAreaAttr: TextAreaAttributes = {
         container: props.attr.container,
         textarea: Object.assign({
             'aria-label': props.label,
-            'aria-describedby': tooltipId
         }, props.attr.textarea),
         pre: props.attr.pre
     };
     const fieldAttr: FormFieldAttributes = {
-        fieldLabel: Object.assign({
-            balloon: {
-                balloonContent: {
-                    id: tooltipId
-                }
-            }
-        }, props.attr.fieldLabel),
+        fieldLabel: props.attr.fieldLabel,
         fieldError: props.attr.fieldError,
         fieldContent: props.attr.fieldContent,
         fieldContainer: props.attr.fieldContainer

--- a/lib/components/Field/TextField.tsx
+++ b/lib/components/Field/TextField.tsx
@@ -69,12 +69,9 @@ export interface TextFieldProps extends React.Props<TextFieldType> {
  * @param props Control properties (defined in `TextFieldProps` interface)
  */
 export const TextField: React.StatelessComponent<TextFieldProps> = (props: TextFieldProps) => {
-    const tooltipId = (!!props.tooltip) ? `${props.name}-tt` : undefined;
     const errorId = `${props.name}-error`;
     let describedby = errorId;
-    if (tooltipId) {
-        describedby += ' ' + tooltipId;
-    }
+
     const textAttr: TextInputAttributes = {
         container: props.attr.container,
         input: Object.assign({
@@ -87,13 +84,7 @@ export const TextField: React.StatelessComponent<TextFieldProps> = (props: TextF
         clearButton: props.attr.clearButton
     };
     const fieldAttr: FormFieldAttributes = {
-        fieldLabel: Object.assign({
-            balloon: {
-                balloonContent: {
-                    id: tooltipId
-                }
-            }
-        }, props.attr.fieldLabel),
+        fieldLabel: props.attr.fieldLabel,
         fieldError: Object.assign({
             id: errorId
         }, props.attr.fieldError),

--- a/lib/components/Field/ToggleField.tsx
+++ b/lib/components/Field/ToggleField.tsx
@@ -54,11 +54,9 @@ export interface ToggleFieldProps extends React.Props<ToggleFieldType> {
  * @param props: Object fulfilling `ToggleFieldProps` interface
  */
 export const ToggleField = React.memo((props: ToggleFieldProps) => {
-    const tooltipId = (!!props.tooltip) ? `${props.name}-tt` : undefined;
     const toggleAttr: ToggleAttributes = {
         container: Object.assign({
             'aria-label': props.label,
-            'aria-describedby': tooltipId
         }, props.attr?.container),
         button: props.attr?.button,
         switch: props.attr?.switch,
@@ -66,13 +64,7 @@ export const ToggleField = React.memo((props: ToggleFieldProps) => {
         text: props.attr?.text
     };
     const fieldAttr: FormFieldAttributes = {
-        fieldLabel: Object.assign({
-            balloon: {
-                balloonContent: {
-                    id: tooltipId
-                }
-            }
-        }, props.attr?.fieldLabel),
+        fieldLabel: props.attr?.fieldLabel,
         fieldError: props.attr?.fieldError,
         fieldContent: props.attr?.fieldContent,
         fieldContainer: props.attr?.fieldContainer,

--- a/lib/components/Input/ComboInput.tsx
+++ b/lib/components/Input/ComboInput.tsx
@@ -482,7 +482,7 @@ export class ComboInput extends React.Component<ComboInputProps, Partial<ComboIn
                             className: css('dropdown')
                         },
                     },
-                    ['host', 'dropdownContainer', 'dropdown']
+                    ['host', 'dropdown']
                 )}
             >
                 <Attr.div

--- a/lib/components/Shell/Shell.tsx
+++ b/lib/components/Shell/Shell.tsx
@@ -64,16 +64,24 @@ export function Shell({ theme, masthead, navigation, children, onClick }: ShellP
 
     return (
         <ThemeProvider theme={shellTheme}>
-            <div className={css('shell')} onClick={onClick}>
-                {masthead && <Masthead navigation={navigation} {...masthead} />}
-                <div className={css('nav-and-workspace')}>
-                    {navigation && <Navigation {...navigation} />}
-                    <section role='main' className={css('workspace')}>
-                        {children}
-                    </section>
-                    <ContextPanelRoot />
+            <>
+                <div className={css('shell')} onClick={onClick}>
+                    {masthead && <Masthead navigation={navigation} {...masthead} />}
+                    <div className={css('nav-and-workspace')}>
+                        {navigation && <Navigation {...navigation} />}
+                        <section role='main' className={css('workspace')}>
+                            {children}
+                        </section>
+                        <ContextPanelRoot />
+                    </div>
                 </div>
-            </div>
+                <div 
+                    id='md-dropdown-container'
+                    aria-live='polite'
+                    aria-atomic='true'
+                    className={css('md-dropdown-container')}
+                />
+            </>
         </ThemeProvider>
     );
 }


### PR DESCRIPTION
The dropdown component was updated to use a React.Portal, because of the way aria live regions works this made it so that the announcement of tooltip text was not being done.

I also noticed that the portal was not actually used as a portal, so I removed it and made the container a live region, so that screen readers announce any changes to that container, therefore announce the tooltip when open.