### PR TITLE
Add name to balloon info icon

### DIFF
--- a/lib/components/Field/FormLabel.tsx
+++ b/lib/components/Field/FormLabel.tsx
@@ -92,6 +92,7 @@ export const FormLabel: React.StatelessComponent<FormLabelProps> = (props: FormL
             )}
         >
             <Icon
+                name={`${props.name}-info`}
                 icon={props.icon}
                 size={IconSize.xsmall}
                 attr={props.attr.icon}


### PR DESCRIPTION
Fixes an accessibility issue to add name to the icon that opens the balloon in form field labels.