### PR TITLE
Fix focus indicator to show on default buttons on focus

### DIFF
--- a/lib/components/Button/Button.module.scss
+++ b/lib/components/Button/Button.module.scss
@@ -61,6 +61,7 @@ $outline-focus-border-width: 1px;
         &:focus {
             background-color: var(--color-bg-btn-standard-focus);
             outline: $outline-focus-border-width dashed var(--color-border-focus);
+            outline-offset: -2px;
         }
 
         &:active {


### PR DESCRIPTION
The focus state for default buttons was not properly set, making it so that it was really hard to see. This updates it so it's the same as the danger and primary buttons.