### PR TITLE
Add error aria label to form error icon

### DIFF
--- a/lib/components/Field/FormError.tsx
+++ b/lib/components/Field/FormError.tsx
@@ -21,6 +21,9 @@ export interface FormErrorProps extends React.Props<FormErrorType> {
     /** Classname to append to top level element */
     className?: string;
 
+    /** Label to be announced before the error message to announce to the user that there's an error */
+    ariaLabel?: string;
+
     attr?: FormErrorAttributes;
 }
 
@@ -39,7 +42,7 @@ export const FormError: React.StatelessComponent<FormErrorProps> = (props: FormE
         >
             {props.children 
                 ? <>
-                    {!props.hideIcon && <Icon icon='errorBadge' size={IconSize.small} className={css('error-badge')} attr={{ container: { title: props.title }}} />}
+                    {!props.hideIcon && <Icon icon='errorBadge' size={IconSize.small} className={css('error-badge')} attr={{ container: { title: props.title, 'aria-label': props.ariaLabel }}} />}
                     <span className={css('inline-text-overflow', 'error-content')} title={props.title}>{props.children}</span>
                 </>
                 : null
@@ -49,6 +52,7 @@ export const FormError: React.StatelessComponent<FormErrorProps> = (props: FormE
 };
 
 FormError.defaultProps = {
+    ariaLabel: 'error',
     attr: {
         container: {}
     }

--- a/lib/components/Field/FormField.tsx
+++ b/lib/components/Field/FormField.tsx
@@ -42,6 +42,8 @@ export interface FormFieldProps extends React.Props<FormFieldType> {
     className?: string;
     /** Classname to append to top level error element */
     errorClassName?: string;
+    /** Label to be announced before the error message to announce to the user that there's an error */
+    errorAriaLabel?: string;
     /** React node to render at the far side of the label. */
     labelFarSide?: React.ReactNode;
 
@@ -158,6 +160,7 @@ export class FormField extends React.PureComponent<FormFieldProps, FormFieldStat
                     hidden={props.hideError}
                     hideIcon={props.loading}
                     title={typeof error === 'string' && error}
+                    ariaLabel={props.errorAriaLabel}
                     attr={{container: {
                         'aria-live': 'polite', // this tags are for screen readers to read the error when it appears
                         'aria-atomic': 'true',


### PR DESCRIPTION
Added aria label to the error icon on formError, this will make it so that any screen reader will announce this label before announcing the actual error message, giving more context to the user that the text they will hear is an error. 

This is added as a prop to allow internationalization.