### PR TITLE
Add transparent borders to separate content in high contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 7.0.20
+### Fixed
+- Added transparent borders to `Masthead` and `SearchInput` to distinguish from content in high contrast mode
+
 ## 7.0.19
 ### Fixed
 - Fixed height on logo for masthead

--- a/lib/components/Masthead/Masthead.module.scss
+++ b/lib/components/Masthead/Masthead.module.scss
@@ -26,6 +26,7 @@ $search-max-size: 100 * $grid-size;
   justify-content: space-between;
   color: var(--color-text-masthead);
   background-color: var(--color-bg-masthead);
+  border-bottom: 1px solid transparent; // transparent border to separate masthead in high contrast mode 
 
   .force-hide-search {
     display: none !important;

--- a/lib/components/SearchInput/SearchInput.module.scss
+++ b/lib/components/SearchInput/SearchInput.module.scss
@@ -75,7 +75,7 @@ $border-radius-size: $grid-size/2;
             color: var(--color-text-searchbar-rest);
             padding-left: $search-icon-width;
             border-radius: $border-radius-size;
-            border: 0 !important;
+            border-bottom: 1px solid transparent; // transparent border to separate masthead in high contrast mode 
 
             &::placeholder {
                 color: var(--color-text-searchbar-rest);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "7.0.19",
+    "version": "7.0.20",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "7.0.19",
+    "version": "7.0.20",
     "description": "Azure IoT UX Fluent Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",


### PR DESCRIPTION
This PR adds transparent borders to `Masthead` and `SearchInput`, not affecting their appearance in normal viewing mode, but allowing the controls to be distinguished from the rest of the content in high contrast mode.