### PR TITLE
Add instanceCount to ensure unique IDs (ARIA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 7.0.23
+### Fixed
+- Added `instanceCount` to `DateField`/`DateTimeField`/`TextField` to ensure unique IDs
+
 ## 7.0.22
 ### Fixed
 - Fixed date picker to update values only if necesary props changed

--- a/lib/components/DateTime/DateField.tsx
+++ b/lib/components/DateTime/DateField.tsx
@@ -3,6 +3,8 @@ import {MethodNode, DateFormat} from '../../Common';
 import {DatePicker, DatePickerAttributes} from './DatePicker';
 import {FormField, FormFieldAttributes} from '../Field/FormField';
 
+let instanceCount = 0; // maintain count to ensure unique IDs (ARIA)
+
 export interface DateFieldType {}
 
 export interface DateFieldProps extends React.Props<DateFieldType> {
@@ -77,7 +79,7 @@ export interface DateFieldProps extends React.Props<DateFieldType> {
  * @deprecated This is not fully localized/accessible. Use https://developer.microsoft.com/en-us/fabric/#/controls/web/datepicker instead.
  */
 export const DateField: React.StatelessComponent<DateFieldProps> = (props: DateFieldProps) => {
-    const errorId = `${props.name}-error`;
+    const errorId = `${props.name}-error-${instanceCount++}`;
     let describedby = errorId;
     const dateAttr: DatePickerAttributes = {
         input: Object.assign({

--- a/lib/components/DateTime/DateTimeField.tsx
+++ b/lib/components/DateTime/DateTimeField.tsx
@@ -8,6 +8,8 @@ import { DatePicker, DatePickerAttributes } from './DatePicker';
 import { DivProps, SpanProps, Elements as Attr } from '../../Attributes';
 const css = classNames.bind(require('./DateTimeField.module.scss'));
 
+let instanceCount = 0; // maintain count to ensure unique IDs (ARIA)
+
 export interface DateTimeFieldType { }
 
 export interface DateTimeFieldAttributes {
@@ -300,7 +302,7 @@ export class DateTimeField extends React.Component<DateTimeFieldProps, Partial<D
     }
 
     render() {
-        const errorId = `${this.props.name}-error`;
+        const errorId = `${this.props.name}-error-${instanceCount++}`;
         let describedby = errorId;
         const dateAttr: DatePickerAttributes = {
             input: Object.assign({

--- a/lib/components/Field/TextField.tsx
+++ b/lib/components/Field/TextField.tsx
@@ -3,6 +3,8 @@ import {MethodNode} from '../../Common';
 import {TextInput, TextInputAttributes} from '../Input/TextInput';
 import {FormField, FormFieldAttributes} from './FormField';
 
+let instanceCount = 0; // maintain count to ensure unique IDs (ARIA)
+
 export interface TextFieldType {}
 
 export interface TextFieldProps extends React.Props<TextFieldType> {
@@ -71,7 +73,7 @@ export interface TextFieldProps extends React.Props<TextFieldType> {
  * @param props Control properties (defined in `TextFieldProps` interface)
  */
 export const TextField: React.StatelessComponent<TextFieldProps> = (props: TextFieldProps) => {
-    const errorId = `${props.name}-error`;
+    const errorId = `${props.name}-error-${instanceCount++}`;
     let describedby = errorId;
 
     const textAttr: TextInputAttributes = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "7.0.22",
+    "version": "7.0.23",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "7.0.22",
+    "version": "7.0.23",
     "description": "Azure IoT UX Fluent Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",


### PR DESCRIPTION
No two `id`s on a page should be the same ([duplicate-id-aria](https://dequeuniversity.com/rules/axe/3.3/duplicate-id-aria?application=msftAI)).

If you have a DateField/DateTimeField/TextField with the same `props.name` then this error will arise.

This PR ensures that no two components will have the same ID. 