### PR TITLE
Allow icon prop in ActionTrigger to be ReactNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # CHANGELOG
 
+## 7.0.24
+### Fixed
+- Changed `icon` prop in `ActionTrigger` to be of type `string | ReactNode`
+
 ## 7.0.23
 ### Fixed
 - Added `instanceCount` to `DateField`/`DateTimeField`/`TextField` to ensure unique IDs
 
 ## 7.0.22
 ### Fixed
-- Fixed date picker to update values only if necesary props changed
+- Fixed date picker to update values only if necessary props changed
 
 ## 7.0.21
 ### Fixed

--- a/lib/components/ActionTrigger/ActionTrigger.tsx
+++ b/lib/components/ActionTrigger/ActionTrigger.tsx
@@ -65,10 +65,10 @@ export const ActionTrigger = React.memo((props: ActionTriggerProps) => {
                     attr={props.attr?.icon}>
                     {props.label}
                 </Icon>
-                : <>
-                    <span className={iconClassName}>{props.icon}</span>
+                : <span className={iconClassName}>
+                    {props.icon}
                     <span className={labelClassName}>{props.label}</span>
-                </>}
+                </span>}
             {suffix}
         </Attr.div>
     );

--- a/lib/components/ActionTrigger/ActionTrigger.tsx
+++ b/lib/components/ActionTrigger/ActionTrigger.tsx
@@ -14,7 +14,7 @@ export interface ActionTriggerAttributes {
 
 export interface ActionTriggerProps {
     /** Icon name (from Segoe UI MDL font) */
-    icon: string;
+    icon: string | React.ReactNode;
     /** Icon name for icon on the right of ActionTrigger (from Segoe UI MDL font) */
     rightIcon?: string;
     /** Action trigger label */
@@ -39,6 +39,8 @@ export const ActionTrigger = React.memo((props: ActionTriggerProps) => {
         'disabled': props.disabled,
         'action-trigger-label-empty': !props.label
     }, props.className);
+    const iconClassName = css('action-trigger-icon');
+    const labelClassName = css('action-trigger-label');
 
     let suffix: React.ReactNode;
     if (props.rightIcon) {
@@ -54,14 +56,19 @@ export const ActionTrigger = React.memo((props: ActionTriggerProps) => {
         <Attr.div
             className={className}
             attr={props.attr?.container}>
-            <Icon
-                icon={props.icon}
-                className={css('action-trigger-icon')}
-                labelClassName={css('action-trigger-label')}
-                size={IconSize.xsmall}
-                attr={props.attr?.icon}>
-                {props.label}
-            </Icon>
+            {typeof props.icon === 'string' 
+                ? <Icon
+                    icon={props.icon}
+                    className={iconClassName}
+                    labelClassName={labelClassName}
+                    size={IconSize.xsmall}
+                    attr={props.attr?.icon}>
+                    {props.label}
+                </Icon>
+                : <>
+                    <span className={iconClassName}>{props.icon}</span>
+                    <span className={labelClassName}>{props.label}</span>
+                </>}
             {suffix}
         </Attr.div>
     );

--- a/lib/components/ActionTrigger/ActionTriggerButton.tsx
+++ b/lib/components/ActionTrigger/ActionTriggerButton.tsx
@@ -15,7 +15,7 @@ export interface ActionTriggerButtonAttributes {
 export interface ActionTriggerButtonProps {
     autoFocus?: boolean;
     /** Icon name (from Segoe UI MDL font) */
-    icon: string;
+    icon: string | React.ReactNode;
     /** Icon name for icon on the right of ActionTrigger (from Segoe UI MDL font) */
     rightIcon?: string;
     /** Action trigger label */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "7.0.23",
+    "version": "7.0.24",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "7.0.23",
+    "version": "7.0.24",
     "description": "Azure IoT UX Fluent Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",


### PR DESCRIPTION
This allows us to pass in Fabric's `Icon` component into `ActionTriggerButton`s