### PR TITLE
Fixes a couple of styling issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 7.0.27
+## Fixed
+- Outline on toggle was hidden when the component didn't have any space to the left
+- Outline on collapsed navigation didn't show correctly one side
+
 ## 7.0.26
 ### Fixed
 - Fixed text color on dropdown for tooltip

--- a/lib/components/Navigation/Navigation.module.scss
+++ b/lib/components/Navigation/Navigation.module.scss
@@ -4,6 +4,7 @@
 $activeBorderHeight: $layout-nav-item-height - (4*$grid-size);
 
 .navigation {
+    box-sizing: content-box;
     // don't allow the size of the nav bar to change:
     width: $layout-nav-collapsed-width;
     flex-shrink: 0;
@@ -79,7 +80,7 @@ $activeBorderHeight: $layout-nav-item-height - (4*$grid-size);
             :global(.global-nav-item), .top-container, .far-bottom-container {
                 // override the width of the nav-item to match the navbar width and take into account the 1px border
                 // that is used to delimitate the nav from the main content
-                width: calc(#{$layout-nav-collapsed-width} - 1px);
+                width: $layout-nav-collapsed-width;
             }
         }
     }

--- a/lib/components/Navigation/Navigation.module.scss
+++ b/lib/components/Navigation/Navigation.module.scss
@@ -78,8 +78,7 @@ $activeBorderHeight: $layout-nav-item-height - (4*$grid-size);
             width: 2 * $layout-nav-collapsed-width;
             
             :global(.global-nav-item), .top-container, .far-bottom-container {
-                // override the width of the nav-item to match the navbar width and take into account the 1px border
-                // that is used to delimitate the nav from the main content
+                // override the width of the nav-item to match the navbar width:
                 width: $layout-nav-collapsed-width;
             }
         }

--- a/lib/components/Navigation/Navigation.module.scss
+++ b/lib/components/Navigation/Navigation.module.scss
@@ -77,8 +77,9 @@ $activeBorderHeight: $layout-nav-item-height - (4*$grid-size);
             width: 2 * $layout-nav-collapsed-width;
             
             :global(.global-nav-item), .top-container, .far-bottom-container {
-                // override the width of the nav-item to match the navbar width:
-                width: $layout-nav-collapsed-width;
+                // override the width of the nav-item to match the navbar width and take into account the 1px border
+                // that is used to delimitate the nav from the main content
+                width: calc(#{$layout-nav-collapsed-width} - 1px);
             }
         }
     }

--- a/lib/components/Toggle/Toggle.module.scss
+++ b/lib/components/Toggle/Toggle.module.scss
@@ -17,6 +17,8 @@ $line-height: 3.5*$grid-size;
     line-height: $line-height;
     background-color: transparent;
     border: none;
+    margin: 0 1px;
+    height: $input-height;
 
     &:not(.disabled):not(.toggle-on):hover,
     &:not(.disabled):not(.toggle-on):focus {
@@ -30,7 +32,6 @@ $line-height: 3.5*$grid-size;
 
     &:focus {
         outline: 1px dashed var(--color-border-focus);
-        outline-offset: 1px;
     }
 
     &.toggle-on {
@@ -99,9 +100,9 @@ $line-height: 3.5*$grid-size;
     // the switch will position correctly if the toggle has
     // any margin or padding
     padding: inherit;
-    margin: inherit;
+    margin: 0;
     left: 1.25*$grid-size;
-    top: 1.25*$grid-size;
+    top: 2.75*$grid-size;
 
     @include rtl {
         left: unset;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "7.0.26",
+    "version": "7.0.27",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "7.0.26",
+    "version": "7.0.27",
     "description": "Azure IoT UX Fluent Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",


### PR DESCRIPTION
Bug fixes for two issues:
- Toggle outline was not correct because the size of the component didn't match the other input components and the left side was hidden if there was no space (margin or padding) in the component.
- Navigation focus would hide the right outline of a navigation item when collapsed.

Before:
![old-nav](https://user-images.githubusercontent.com/2132567/75722660-7d456500-5c8f-11ea-9f70-339af4a20c57.PNG)

![old-toggle](https://user-images.githubusercontent.com/2132567/75722662-7d456500-5c8f-11ea-831f-1bf94b048e05.PNG)

After:

![new-nav](https://user-images.githubusercontent.com/2132567/75722659-7cacce80-5c8f-11ea-9bbe-57adb30eb93d.PNG)

![new-toggle](https://user-images.githubusercontent.com/2132567/75722661-7d456500-5c8f-11ea-9d4e-6341b8739c01.PNG)

