### PR TITLE
Fix icon sizing to actually constraint icons

### DIFF
--- a/lib/components/Icon/Icon.module.scss
+++ b/lib/components/Icon/Icon.module.scss
@@ -11,6 +11,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    padding: 1px;
     
     &:before {
         @include md-box(inline-block, relative);
@@ -37,9 +38,7 @@
 
 .icon-xsmall {
     @extend %icon;
-    .icon-xsmall:before {
-        font-size: var(--icon-size-xsmall);
-    }
+    font-size: var(--icon-size-xsmall);
 
     &.centered {
         @extend %centered;
@@ -48,9 +47,7 @@
 
 .icon-small {
     @extend %icon;
-    .icon-small:before {
-        font-size: var(--icon-size-small);
-    }
+    font-size: var(--icon-size-small);
 
     &.centered {
         @extend %centered;
@@ -59,9 +56,7 @@
 
 .icon-medium {
     @extend %icon;
-    .icon-medium:before {
-        font-size: var(--icon-size-medium);
-    }
+    font-size: var(--icon-size-medium);
 
     &.centered {
         @extend %centered;
@@ -70,9 +65,7 @@
 
 .icon-large {
     @extend %icon;
-    .icon-large:before {
-        font-size: var(--icon-size-large);
-    }
+    font-size: var(--icon-size-large);
 
     &.centered {
         @extend %centered;
@@ -81,9 +74,7 @@
 
 .icon-xlarge {
     @extend %icon;
-    .icon-xlarge:before {
-        font-size: var(--icon-size-xlarge);
-    }
+    font-size: var(--icon-size-xlarge);
 
     &.centered {
         @extend %centered;
@@ -92,9 +83,7 @@
 
 .icon-xxlarge {
     @extend %icon;
-    .icon-xxlarge:before {
-        font-size: var(--icon-size-xxlarge);
-    }
+    font-size: var(--icon-size-xxlarge);
 
     &.centered {
         @extend %centered;

--- a/lib/components/Icon/Icon.tsx
+++ b/lib/components/Icon/Icon.tsx
@@ -18,14 +18,12 @@ export enum IconSize {
     xxlarge
 }
 
-export interface IconType {}
-
 export interface IconAttributes {
     container?: SpanProps;
     label?: SpanProps;
 }
 
-export interface IconProps extends React.Props<IconType> {
+export interface IconProps {
     /** Icon name (from icons.css) */
     icon: string;
 
@@ -61,6 +59,8 @@ export interface IconProps extends React.Props<IconType> {
      */
     labelClassName?: string;
 
+    children?: React.ReactNode;
+
     attr?: IconAttributes;
 }
 
@@ -71,33 +71,25 @@ export interface IconProps extends React.Props<IconType> {
  *
  * @param props Control properties (Defined in `IconProps` interface)
  */
-export const Icon: React.StatelessComponent<IconProps> = (props: IconProps) => {
-    let iconClassName = `icon-${props.icon}`;
-    let cls = css({
+export const Icon = React.memo((props: IconProps) => {
+    const iconClassName = `icon-${props.icon}`;
+    const cls = css({
         'icon-xsmall': props.size === IconSize.xsmall,
         'icon-small': props.size === IconSize.small,
-        'icon-medium': props.size === IconSize.medium,
+        'icon-medium': props.size == null || props.size === IconSize.medium,
         'icon-large': props.size === IconSize.large,
         'icon-xlarge': props.size === IconSize.xlarge,
         'icon-xxlarge': props.size === IconSize.xxlarge,
         'centered': props.centered,
     }, iconClassName, props.className);
 
-    let style = { color: props.color };
-    if (props.fontSize) {
-        style['fontSize'] = `${props.fontSize}px`;
+    const style: any = { };
+    if (props.color) {
+        style.color = props.color;
     }
 
-    let label;
-    if (props.children) {
-        label = (
-            <Attr.span
-                className={props.labelClassName}
-                attr={props.attr?.label}
-            >
-                {props.children}
-            </Attr.span>
-        );
+    if (props.fontSize) {
+        style.fontSize = `${props.fontSize}px`;
     }
 
     return (
@@ -106,18 +98,16 @@ export const Icon: React.StatelessComponent<IconProps> = (props: IconProps) => {
             style={style}
             attr={props.attr?.container}
         >
-            {label}
+            {props.children && (
+                <Attr.span
+                    className={props.labelClassName}
+                    attr={props.attr?.label}
+                >
+                    {props.children}
+                </Attr.span>
+            )}
         </Attr.span>
     );
-};
-
-Icon.defaultProps = {
-    icon: undefined,
-    size: IconSize.medium,
-    attr: {
-        container: {},
-        label: {}
-    }
-};
+});
 
 export default Icon;

--- a/lib/components/Masthead/Masthead.tsx
+++ b/lib/components/Masthead/Masthead.tsx
@@ -10,7 +10,7 @@ import { Elements as Attr } from '../../Attributes';
 import { SearchInput } from '../SearchInput/SearchInput';
 import { TextInputAttributes } from '../Input/TextInput';
 import { ShellTheme  } from '../Shell';
-import { Icon } from '../Icon';
+import { Icon, IconSize } from '../Icon';
 
 const cx = classnames.bind(require('./Masthead.module.scss'));
 
@@ -147,7 +147,10 @@ export class Masthead extends React.PureComponent<MastheadProperties> {
                         className={cx('nav-container', { 'force-hide-search': expanded })}>
                             <StyledButton
                                 className={cx('masthead-btn')}>
-                                    <Icon icon='chevronRight' className={cx({
+                                    <Icon 
+                                        icon='chevronRight'
+                                        size={IconSize.xsmall}
+                                        className={cx({
                                         'nav-icon-collapsed': !navigation.isExpanded,
                                         'nav-icon-expanded': navigation.isExpanded, 
                                     })} />
@@ -179,7 +182,7 @@ export class Masthead extends React.PureComponent<MastheadProperties> {
                                     attr={{ button: { title: search.label } }}
                                     onClick={search.onExpand}
                                     className={cx('masthead-btn')}>
-                                        <Icon icon='search'/>
+                                        <Icon icon='search' size={IconSize.xsmall} />
                                 </StyledButton>
                             </li>}
                             {more && !more.selected && items}
@@ -194,7 +197,7 @@ export class Masthead extends React.PureComponent<MastheadProperties> {
                                             title={more.title}
                                             onClick={more.onClick}
                                             className={cx('masthead-btn', 'more-menu-btn', { 'selected': more.selected })}>
-                                                <Icon icon='more'/>
+                                                <Icon icon='more' size={IconSize.xsmall} />
                                         </StyledButton>
                                         <InlinePopup.Panel
                                             alignment='right'

--- a/lib/components/SearchInput/SearchInput.tsx
+++ b/lib/components/SearchInput/SearchInput.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as classNames from 'classnames/bind';
-import { Icon } from '../Icon';
+import { Icon, IconSize } from '../Icon';
 import TextInput, { TextInputType, TextInputAttributes } from '../Input/TextInput';
 import { ActionTriggerButton } from '../ActionTrigger';
 const css = classNames.bind(require('./SearchInput.module.scss'));
@@ -31,7 +31,7 @@ export const SearchInput = React.memo((props: SearchInputProps) => {
 
     return (
         <form className={css('search-input-container', props.containerClassName)} onSubmit={props.onSubmit} role='search'>
-            <Icon icon='search' className={css('search-prefix-icon')} />
+            <Icon icon='search' className={css('search-prefix-icon')} size={IconSize.xsmall} />
             <TextInput
                 name='search-input'
                 value={props.value == null ? '' : props.value}


### PR DESCRIPTION
Icons sizes where being set on the `.icon-${size} .icon-${size}:before`, since we don't have any nested `icon-${size}` elements in our DOM it was (since always) being ignore, this made every icon just constraint to the size of the icon symbol itself (in most cases around 14 pixels height and auto width).

With this change the icons will actually take our sizes into account.

 This PR also cleans up the icon component and wrapps it in a memo.