### PR TITLE
Fix wrongly used attr

### DIFF
--- a/lib/components/Field/ToggleField.tsx
+++ b/lib/components/Field/ToggleField.tsx
@@ -60,9 +60,8 @@ export const ToggleField = React.memo((props: ToggleFieldProps) => {
         container: Object.assign({
             'aria-label': props.label,
         }, props.attr?.container),
-        button: props.attr?.button,
+        switchContainer: props.attr?.switchContainer,
         switch: props.attr?.switch,
-        border: props.attr?.border,
         text: props.attr?.text
     };
     const fieldAttr: FormFieldAttributes = {

--- a/lib/components/Toggle/Toggle.tsx
+++ b/lib/components/Toggle/Toggle.tsx
@@ -12,7 +12,7 @@ export interface ToggleType {}
 
 export interface ToggleAttributes {
     container?: DivProps;
-    button?: ButtonProps;
+    switchContainer?: DivProps;
     border?: DivProps;
     switch?: DivProps;
     text?: DivProps;
@@ -91,7 +91,7 @@ export const Toggle = React.memo((props: ToggleProps) => {
             attr={props.attr?.container}>
             <ToggleSwitchContainerProxy 
                 className={css('toggle-switch-container')}
-                attr={props.attr?.container}
+                attr={props.attr?.switchContainer}
             />
             <ToggleSwitchProxy className={css('toggle-switch')} attr={props.attr?.switch}/>
             <Attr.div className={css('toggle-label')} attr={props.attr?.text}>


### PR DESCRIPTION
Toggle input component was reusing the `container` attr twice, this is a mistake since every component should have it's own attr reference.