### PR TITLE
Refactor masthead to use memo and fix styling

### DIFF
--- a/lib/common/_constants.scss
+++ b/lib/common/_constants.scss
@@ -1,3 +1,4 @@
 @import "~@microsoft/azure-iot-ux-fluent-css/src/constants";
 
 $component-border-radius: 2px;
+$search-max-width: 100 * $grid-size;

--- a/lib/components/Alert/Alert.module.scss
+++ b/lib/components/Alert/Alert.module.scss
@@ -72,7 +72,6 @@ $line-height-close: 4*$grid-size;
     &.alert-info {
         background-color: var(--color-bg-alert-info);
         color: var(--color-text-alert-info);
-        }
     }
 
     &.alert-warning {

--- a/lib/components/Masthead/Masthead.module.scss
+++ b/lib/components/Masthead/Masthead.module.scss
@@ -165,8 +165,8 @@ $masthead-collapse-start: 125 * $grid-size;
     }
 
     &.selected {
-      background-color: var(--color-bg-container-panel) !important;
-      color: var(--color-text-rest) !important;
+      background-color: var(--color-bg-container-panel);
+      color: var(--color-text-rest);
 
       &:focus {
         outline: 1px dashed var(--color-outline);

--- a/lib/components/Masthead/Masthead.module.scss
+++ b/lib/components/Masthead/Masthead.module.scss
@@ -1,19 +1,7 @@
 @import "../../common/constants";
 @import "../../common/mixins";
 
-$masthead-branding-width: 50%;
-
-$masthead-brandname-width: $grid-size * 50;
-$masthead-application-breakpoint: 3 * $masthead-brandname-width - 1;
 $masthead-collapse-start: 125 * $grid-size;
-$thumbnail-size: 3 * $gutter-xsmall; // match @user-thumbnail-size in Thumbnail.module.scss
-$branding-min-width-size: 30 * $grid-size;
-$search-max-size: 100 * $grid-size;
-
-@mixin action-trigger-override {
-  outline: none;
-  color: var(--color-text-masthead);
-}
 
 .masthead {
   // The masthead should not grow or shrink, it should always be $layout-masthead-height
@@ -23,67 +11,9 @@ $search-max-size: 100 * $grid-size;
 
   // Position its content
   display: flex;
-  justify-content: space-between;
+  align-items: center;
   color: var(--color-text-masthead);
   background-color: var(--color-bg-masthead);
-
-  .force-hide-search {
-    display: none !important;
-  }
-
-  .force-show-search {
-    display: block !important;
-    width: 100%;
-    max-width: unset;
-  }
-
-  .nav-container {
-    // show nav in masthead only in small screens:
-    display: none;
-    color: var(--color-text-masthead);
-
-    .nav-panel {
-      width: $layout-nav-expanded-width;
-      padding: 0;
-      border: 0;
-    }
-
-    .nav-icon-collapsed {
-      transform: rotate(90deg);
-    }
-
-    .nav-icon-expanded {
-      transform: rotate(-90deg);
-    }
-
-    :global(.global-nav-item) {
-      background-color: var(--color-bg-container-panel);
-      color: var(--color-text-regular) !important;
-      border-left: $grid-size solid transparent;
-      @include rtl {
-        border-left: none;
-        border-right: $grid-size solid transparent;
-      }
-
-      &:hover,
-      &:active,
-      &:global(.global-nav-item-active) {
-        background-color: var(--color-bg-masthead-active);
-        border-color: var(--color-border-navbar-selected);
-        @extend %semibold;
-      }
-    }
-
-    :global(.global-nav-item-container-title) {
-      background-color: var(--color-bg-container-panel);
-      color: var(--color-text-rest);
-    }
-
-    @media (max-width: $screen-sm - 1) {
-      width: $layout-nav-collapsed-width;
-      display: initial;
-    }
-  }
 
   .masthead-logo {
     display: flex;
@@ -96,66 +26,68 @@ $search-max-size: 100 * $grid-size;
     }
   }
 
-  .masthead-branding {
-    width: $masthead-branding-width;
-    height: $layout-masthead-height;
-    display: inline-block;
-    padding: 0px $gutter-small;
-    line-height: $layout-masthead-height;
-    font-size: var(--font-size-h3);
-    font-weight: bold;
-    min-width: $branding-min-width-size;
+  .branding-container {
+    display: flex;
+    flex-grow: 1;
+    height: 100%;
+    overflow: hidden;
 
-    @media (max-width: $screen-md - 1) {
-      width: 100%;
+    &.with-search {
+      @media (min-width: $screen-lg) {
+        max-width: calc(50% - #{$search-max-width / 2});
+      }
     }
   }
 
+  .masthead-branding {
+    flex-grow: 1;
+    display: block;
+    padding: 0px $gutter-small;
+    font-size: var(--font-size-h3);
+    font-weight: bold;
+    align-self: center;
+  }
+
   .search-input-container {
-    @media (max-width: $screen-md - 1) {
-      display: none;
+    &:not(.expanded) {
+      @media (max-width: $screen-md - 1) {
+        display: none;
+      }
+    }
+
+    &.expanded {
+      max-width: unset;
+      padding: 0 $gutter-normal;
     }
   }
 
   .masthead-toolbar-container {
-    width: calc(100% - #{$masthead-branding-width});
-    text-align: right;
+    flex-grow: 1;
     position: relative;
+    display: flex;
+    justify-content: flex-end;
+  }
+  
+  .masthead-toolbar {
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+    list-style-type: none;
 
-    @media (max-width: $screen-md - 1) {
-      width: auto;
+    // hide the search-button that control the display of search-bar
+    .search-button {
+      @media (min-width: $screen-lg) {
+        display: none;
+      }
     }
 
-    .masthead-toolbar {
-      margin: 0;
-      padding: 0;
-      display: flex;
-      flex-direction: row;
-      flex-wrap: nowrap;
-      justify-content: flex-end;
-      list-style-type: none;
-
-      // hide the search-button that control the display of search-bar
-      .search-button {
-        @media (min-width: $screen-md) {
-          display: none;
-        }
+    .more-button {
+      @media (min-width: $screen-sm) {
+        display: none;
       }
-
-      .more-button {
-        @media (min-width: $screen-sm) {
-          display: none;
-        }
-      }
-
-      // hide the buttons container if the more button is not selected on small screen
-      // we are reusing the se list of item to populate the toolbar btn container and the inline popup
-      .masthead-toolbar-btn-container:not(.selected-more) {
-        @media (max-width: $screen-sm - 1) {
-          display: none;
-        }
-      }
-
+    
       .masthead-toolbar-menu {
         padding: 0;
         background-color: var(--color-bg-container-panel);
@@ -186,139 +118,140 @@ $search-max-size: 100 * $grid-size;
     }
   }
 
-  .masthead-btn {
-    background-color: transparent;
-    width: $layout-masthead-height;
-    height: $layout-masthead-height;
-    justify-content: center;
-    align-items: center;
-    border: none;
-    white-space: nowrap;
-    text-decoration: none;
-    padding: 0;
-    display: inline-flex;
-    cursor: pointer;
-    vertical-align: middle;
-    align-content: center;
+  // hide the buttons container if the more button is not selected on small screen
+  // we are reusing the se list of item to populate the toolbar btn container and the inline popup
+  .masthead-toolbar-btn-container:not(.selected-more) {
+    @media (max-width: $screen-sm - 1) {
+      display: none;
+    }
+  }
+}
+
+.masthead-btn {
+  background-color: transparent;
+  width: $layout-masthead-height;
+  height: $layout-masthead-height;
+  justify-content: center;
+  align-items: center;
+  border: none;
+  padding: 0;
+  display: inline-flex;
+  cursor: pointer;
+  vertical-align: middle;
+  align-content: center;
+  color: inherit;
+  color: var(--color-text-masthead);
+
+  > div span {
     color: inherit;
-    color: var(--color-text-masthead);
+  }
 
-    > div span {
-      color: inherit;
+  &:focus,
+  &:active {
+    outline-offset: -1px;
+    outline: 1px dashed var(--color-outline-masthead);
+  }
+
+  // align all the icons
+  :before {
+    width: var(--icon-size-base);
+    height: var(--icon-size-base);
+    vertical-align: baseline;
+  }
+
+  &.masthead-toolbar-btn {
+    &:hover {
+      background-color: var(--color-bg-masthead-hover);
     }
 
-    &:focus,
-    &:active {
-      outline-offset: -1px;
-      outline: 1px dashed var(--color-outline-masthead);
+    &.selected {
+      background-color: var(--color-bg-container-panel) !important;
+      color: var(--color-text-rest) !important;
+
+      &:focus {
+        outline: 1px dashed var(--color-outline);
+      }
     }
 
-    // align all the icons
-    :before {
-      width: var(--icon-size-base);
-      height: var(--icon-size-base);
-      vertical-align: baseline;
-    }
-
-    &.masthead-toolbar-btn {
+    @media (max-width: $screen-sm + 1) {
+      color: var(--color-text-rest);
       &:hover {
-        background-color: var(--color-bg-masthead-hover);
+        background-color: var(--color-bg-hover);
       }
 
-      &.selected {
-        background-color: var(--color-bg-container-panel) !important;
-        color: var(--color-text-rest) !important;
-
-        &:focus {
-          outline: 1px dashed var(--color-outline);
-        }
+      > span {
+        padding: $gutter-small;
+        width: 100%;
+        justify-content: flex-start;
       }
+    }
 
-      @media (max-width: $screen-sm + 1) {
-        color: var(--color-text-rest);
-        &:hover {
-          background-color: var(--color-bg-hover);
-        }
-
-        > span {
-          padding: $gutter-small;
-          width: 100%;
-          justify-content: flex-start;
-        }
-      }
-
-      > span > span {
-        // show the label of the action trigger button inside the inline popup of the more button
-        @media (min-width: $screen-sm) {
-          // $screen-sm: 480px;
-          display: none;
-        }
+    > span > span {
+      // show the label of the action trigger button inside the inline popup of the more button
+      @media (min-width: $screen-sm) {
+        // $screen-sm: 480px;
+        display: none;
       }
     }
   }
+}
 
-  // RTL
-  @include rtl {
-    .masthead-branding {
-      direction: rtl;
-      margin-left: unset;
-      margin-right: 0;
+
+// ================= Mobile
+
+.nav-container {
+  // show nav in masthead only in small screens:
+  display: none;
+  color: var(--color-text-masthead);
+
+  .nav-panel {
+    width: $layout-nav-expanded-width;
+    padding: 0;
+    border: 0;
+  }
+
+  .nav-icon-collapsed {
+    transform: rotate(90deg);
+  }
+
+  .nav-icon-expanded {
+    transform: rotate(-90deg);
+  }
+
+  :global(.global-nav-item) {
+    background-color: var(--color-bg-container-panel);
+    color: var(--color-text-regular);
+    border-left: $grid-size solid transparent;
+    
+    @include rtl {
+      border-left: none;
+      border-right: $grid-size solid transparent;
     }
 
-    .masthead-toolbar-container {
-      direction: rtl;
-      text-align: left;
-
-      .masthead-toolbar-menu {
-        ul {
-          padding-right: 0;
-        }
-      }
-
-      .masthead-toolbar-btn {
-        border-right: 1px solid var(--color-border-panel);
-        border-left: 0;
-      }
+    &:hover,
+    &:active {
+      background-color: var(--color-bg-container-panel);
+      color: var(--color-text-regular);
     }
-
-    .user-menu-item {
-      .user-label,
-      .user-items {
-        > * {
-          text-align: right;
-        }
-      }
+    
+    &:global(.global-nav-item-active) {
+      background-color: var(--color-bg-masthead-active);
+      border-color: var(--color-border-navbar-selected);
+      @extend %semibold;
     }
+  }
+
+  :global(.global-nav-item-container-title) {
+    background-color: var(--color-bg-container-panel);
+    color: var(--color-text-rest);
+  }
+
+  @media (max-width: $screen-sm - 1) {
+    width: $layout-nav-collapsed-width;
+    display: initial;
   }
 }
 
 .separator {
   border-top: 1px solid var(--color-border-panel);
-}
-
-// MIXIN
-@mixin collapse($count) {
-  $breakpoint: $masthead-collapse-start - $count * $layout-nav-item-height;
-
-  @media (min-width: $breakpoint + 1) {
-    .collapse-#{$count}-inverse {
-      display: none;
-    }
-  }
-
-  @media (max-width: $breakpoint) {
-    .collapse-#{$count} {
-      display: none;
-    }
-  }
-}
-
-@for $i from 0 through 10 {
-  @include collapse($i);
-}
-
-@media (max-width: $masthead-application-breakpoint) {
-  .masthead-branding * + * {
-    display: none;
-  }
 }

--- a/lib/components/Masthead/Masthead.tsx
+++ b/lib/components/Masthead/Masthead.tsx
@@ -6,7 +6,7 @@ import { MethodNode } from '../../Common';
 import * as InlinePopup from '../InlinePopup';
 import { NavigationProperties } from '../Navigation/Navigation';
 import { ActionTriggerAttributes, ActionTriggerButtonAttributes } from '../ActionTrigger';
-import { Elements as Attr } from '../../Attributes';
+import { Elements as Attr, SpanProps, DivProps } from '../../Attributes';
 import { SearchInput } from '../SearchInput/SearchInput';
 import { TextInputAttributes } from '../Input/TextInput';
 import { ShellTheme  } from '../Shell';
@@ -59,8 +59,14 @@ export interface MastheadUserItem {
     attr?: InlinePopup.Attributes;
 }
 
+interface MastheadAttributes {
+    brandingContainer?: DivProps;
+    branding?: SpanProps;
+    logo?: DivProps;
+}
+
 export interface MastheadProperties {
-    branding: MethodNode;
+    branding: string;
     logo?: MethodNode;
     navigation?: NavigationProperties;
     search?: MastheadSearchItem;
@@ -72,6 +78,7 @@ export interface MastheadProperties {
     };
     toolbarItems?: Array<MastheadToolbarItem>;
     user?: React.ReactNode;
+    attr?: MastheadAttributes;
 }
 
 // Root container
@@ -103,122 +110,110 @@ const StyledButton = styled(Attr.button)`
     }
 `;
 
-export class Masthead extends React.PureComponent<MastheadProperties> {
+export const Masthead = React.memo((props: MastheadProperties) => {
+    const { navigation, user, search, more, logo, branding, attr } = props;
 
-    getToolbarItems = () => {
-        if (!this.props.toolbarItems) {
-            return null;
-        }
-        return this.props.toolbarItems.map((item, idx) => {
-            const { label, icon, onClick, selected, attr } = item;
-            return (
-                <li key={idx} className={cx('masthead-toolbar-btn-container', { 'selected-more': this.props.more.selected })}>
-                    <StyledButton
-                        title={label}
-                        attr={attr}
-                        onClick={onClick}
-                        className={cx('masthead-btn', 'masthead-toolbar-btn', { selected })}>
-                            <Icon icon={icon}>{label}</Icon>
-                    </StyledButton>
-                </li>
-            );
-        });
-    }
-
-    render() {
-        const {
-            navigation,
-            user,
-            search,
-            more,
-            logo,
-            branding
-        } = this.props;
-
-        const items = this.getToolbarItems();
-        const expanded = search && search.expanded;
-
+    const items = props.toolbarItems?.map((item, idx) => {
+        const { label, icon, onClick, selected, attr } = item;
         return (
-            <MastheadContainer key='Masthead' role='banner' className={cx('masthead')}>
-                {navigation &&
-                    <InlinePopup.Container
-                        expanded={navigation.isExpanded}
-                        onClick={navigation.onClick}
-                        className={cx('nav-container', { 'force-hide-search': expanded })}>
-                            <StyledButton
-                                className={cx('masthead-btn')}>
-                                    <Icon 
-                                        icon='chevronRight'
-                                        size={IconSize.xsmall}
-                                        className={cx({
-                                        'nav-icon-collapsed': !navigation.isExpanded,
-                                        'nav-icon-expanded': navigation.isExpanded, 
-                                    })} />
-                            </StyledButton>
-                        <InlinePopup.Panel alignment='left' className={cx('nav-panel')}>
-                            {navigation.children}
-                            <div className={cx('separator')}></div>
-                            {navigation.farBottomChildren}
-                        </InlinePopup.Panel>
-                    </InlinePopup.Container>
-                }
-                {logo && <Attr.div key={'masthead-logo'} className={cx('masthead-logo', { 'force-hide-search': expanded })}>{logo}</Attr.div>}
-                <Attr.span key={'masthead-branding'} className={cx('masthead-branding', 'inline-text-overflow', { 'force-hide-search': expanded })}>{branding}</Attr.span>
-                {search && <SearchInput
-                    containerClassName={cx('search-input-container', { 'force-show-search': expanded })}
-                    inputClassName={cx('masthead-search-input')}
-                    onChange={search.onChange}
-                    value={search.value}
-                    onSubmit={search.onSubmit}
-                    label={search.label}
-                    attr={search.attr}
-                />}
-                <ThemeProvider theme={toolbarButtonTheme}>
-                    <Attr.div className={cx('masthead-toolbar-container', { 'force-hide-search': expanded })}>
-                        <ul className={cx('masthead-toolbar')}>
-                            {search && <li key='item-search' className={cx('search-button')}>
-                                <StyledButton
-                                    key={search.label}
-                                    attr={{ button: { title: search.label } }}
-                                    onClick={search.onExpand}
-                                    className={cx('masthead-btn')}>
-                                        <Icon icon='search' size={IconSize.xsmall} />
-                                </StyledButton>
-                            </li>}
-                            {more && !more.selected && items}
-                            {more &&
-                                <li key='item-more' className={cx('more-button')} title={more.attr?.ariaLabel}>
-                                    <InlinePopup.Container
-                                        expanded={more.selected}
-                                        onClick={more.onClick}
-                                        attr={more.attr}>
-                                        <StyledButton
-                                            attr={more.attr}
-                                            title={more.title}
-                                            onClick={more.onClick}
-                                            className={cx('masthead-btn', 'more-menu-btn', { 'selected': more.selected })}>
-                                                <Icon icon='more' size={IconSize.xsmall} />
-                                        </StyledButton>
-                                        <InlinePopup.Panel
-                                            alignment='right'
-                                            className={cx('masthead-toolbar-menu')}
-                                        >
-                                            <ul role='menu' id='more-menu'>
-                                                {items}
-                                            </ul>
-                                        </InlinePopup.Panel>
-                                    </InlinePopup.Container>
-                                </li>
-                            }
-                            {user && <li key='user-menu' className={cx('user-menu-item')}>
-                                {user}
-                            </li>}
-                        </ul >
-                    </Attr.div>
-                </ThemeProvider>
-            </MastheadContainer>
+            <li key={idx} className={cx('masthead-toolbar-btn-container', { 'selected-more': props.more.selected })}>
+                <StyledButton
+                    title={label}
+                    attr={attr}
+                    onClick={onClick}
+                    className={cx('masthead-btn', 'masthead-toolbar-btn', { selected })}>
+                        <Icon icon={icon} labelClassName={cx('inline-text-overflow')}>{label}</Icon>
+                </StyledButton>
+            </li>
         );
-    }
-}
+    });
+
+    const searchExpanded = search?.expanded;
+
+    return (
+        <MastheadContainer key='Masthead' role='banner' className={cx('masthead')}>
+            {navigation && !searchExpanded &&
+                <InlinePopup.Container
+                    expanded={navigation.isExpanded}
+                    onClick={navigation.onClick}
+                    className={cx('nav-container')}>
+                        <StyledButton
+                            className={cx('masthead-btn')}>
+                                <Icon
+                                    icon='chevronRight'
+                                    size={IconSize.xsmall}
+                                    className={cx({
+                                    'nav-icon-collapsed': !navigation.isExpanded,
+                                    'nav-icon-expanded': navigation.isExpanded, 
+                                })} />
+                        </StyledButton>
+                    <InlinePopup.Panel alignment='left' className={cx('nav-panel')}>
+                        {navigation.children}
+                        { navigation.farBottomChildren &&
+                            <>
+                                <div className={cx('separator')}></div>
+                                {navigation.farBottomChildren}
+                            </>
+                        }
+                    </InlinePopup.Panel>
+                </InlinePopup.Container>
+            }
+            { !searchExpanded && <Attr.div className={cx('branding-container', { 'with-search': !!search })} attr={attr?.brandingContainer}>
+                {logo && <Attr.div key='masthead-logo' className={cx('masthead-logo')} attr={attr?.logo}>{logo}</Attr.div>}
+                <Attr.span key='masthead-branding' title={branding} className={cx('masthead-branding', 'inline-text-overflow')} attr={attr?.branding}>{branding}</Attr.span>
+            </Attr.div>}
+            {search && <SearchInput
+                containerClassName={cx('search-input-container', { 'expanded': searchExpanded })}
+                inputClassName={cx('masthead-search-input')}
+                onChange={search.onChange}
+                value={search.value}
+                onSubmit={search.onSubmit}
+                label={search.label}
+                attr={search.attr}
+            />}
+            <ThemeProvider theme={toolbarButtonTheme}>
+                {!searchExpanded && <Attr.div className={cx('masthead-toolbar-container')}>
+                    <ul className={cx('masthead-toolbar')}>
+                        {search && <li key='item-search' className={cx('search-button')}>
+                            <StyledButton
+                                key={search.label}
+                                attr={{ button: { title: search.label } }}
+                                onClick={search.onExpand}
+                                className={cx('masthead-btn')}>
+                                    <Icon icon='search' size={IconSize.xsmall} />
+                            </StyledButton>
+                        </li>}
+                        {more && !more.selected && items}
+                        {more &&
+                            <li key='item-more' className={cx('more-button')} title={more.attr?.ariaLabel}>
+                                <InlinePopup.Container
+                                    expanded={more.selected}
+                                    onClick={more.onClick}
+                                    attr={more.attr}>
+                                    <StyledButton
+                                        attr={more.attr}
+                                        title={more.title}
+                                        className={cx('masthead-btn', 'more-menu-btn', { 'selected': more.selected })}>
+                                            <Icon icon='more' size={IconSize.xsmall} />
+                                    </StyledButton>
+                                    <InlinePopup.Panel
+                                        alignment='right'
+                                        className={cx('masthead-toolbar-menu')}>
+                                        <ul role='menu' id='more-menu'>
+                                            {items}
+                                        </ul>
+                                    </InlinePopup.Panel>
+                                </InlinePopup.Container>
+                            </li>
+                        }
+                        {user && <li key='user-menu' className={cx('user-menu-item')}>
+                            {user}
+                        </li>}
+                    </ul >
+                </Attr.div>}
+            </ThemeProvider>
+        </MastheadContainer>
+    );
+});
 
 export default Masthead;

--- a/lib/components/Masthead/Masthead.tsx
+++ b/lib/components/Masthead/Masthead.tsx
@@ -122,7 +122,7 @@ export const Masthead = React.memo((props: MastheadProperties) => {
                     attr={attr}
                     onClick={onClick}
                     className={cx('masthead-btn', 'masthead-toolbar-btn', { selected })}>
-                        <Icon icon={icon} labelClassName={cx('inline-text-overflow')} icon={IconSize.xsmall}>{label}</Icon>
+                        <Icon icon={icon} labelClassName={cx('inline-text-overflow')} size={IconSize.xsmall}>{label}</Icon>
                 </StyledButton>
             </li>
         );

--- a/lib/components/Masthead/Masthead.tsx
+++ b/lib/components/Masthead/Masthead.tsx
@@ -149,7 +149,7 @@ export const Masthead = React.memo((props: MastheadProperties) => {
                         </StyledButton>
                     <InlinePopup.Panel alignment='left' className={cx('nav-panel')}>
                         {navigation.children}
-                        { navigation.farBottomChildren &&
+                        {navigation.farBottomChildren &&
                             <>
                                 <div className={cx('separator')}></div>
                                 {navigation.farBottomChildren}
@@ -158,7 +158,7 @@ export const Masthead = React.memo((props: MastheadProperties) => {
                     </InlinePopup.Panel>
                 </InlinePopup.Container>
             }
-            { !searchExpanded && <Attr.div className={cx('branding-container', { 'with-search': !!search })} attr={attr?.brandingContainer}>
+            {!searchExpanded && <Attr.div className={cx('branding-container', { 'with-search': !!search })} attr={attr?.brandingContainer}>
                 {logo && <Attr.div key='masthead-logo' className={cx('masthead-logo')} attr={attr?.logo}>{logo}</Attr.div>}
                 <Attr.span key='masthead-branding' title={branding} className={cx('masthead-branding', 'inline-text-overflow')} attr={attr?.branding}>{branding}</Attr.span>
             </Attr.div>}

--- a/lib/components/Masthead/Masthead.tsx
+++ b/lib/components/Masthead/Masthead.tsx
@@ -122,7 +122,7 @@ export const Masthead = React.memo((props: MastheadProperties) => {
                     attr={attr}
                     onClick={onClick}
                     className={cx('masthead-btn', 'masthead-toolbar-btn', { selected })}>
-                        <Icon icon={icon} labelClassName={cx('inline-text-overflow')}>{label}</Icon>
+                        <Icon icon={icon} labelClassName={cx('inline-text-overflow')} icon={IconSize.xsmall}>{label}</Icon>
                 </StyledButton>
             </li>
         );

--- a/lib/components/SearchInput/SearchInput.module.scss
+++ b/lib/components/SearchInput/SearchInput.module.scss
@@ -52,7 +52,7 @@ $border-radius-size: $grid-size/2;
         background-color: transparent;
         position: absolute;
         z-index: 1;
-        margin-left: 3*$grid-size;
+        margin-left: 2*$grid-size;
         height: 100%;
         border: 0;
         background: transparent;

--- a/lib/components/Toggle/Toggle.tsx
+++ b/lib/components/Toggle/Toggle.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as classNames from 'classnames/bind';
 import styled, { ThemeProps } from 'styled-components';
 
-import {DivProps, ButtonProps, Elements as Attr} from '../../Attributes';
+import {DivProps, Elements as Attr} from '../../Attributes';
 import {MethodNode, autoFocusRef} from '../../Common';
 import { ShellTheme } from '../Shell';
 
@@ -13,7 +13,6 @@ export interface ToggleType {}
 export interface ToggleAttributes {
     container?: DivProps;
     switchContainer?: DivProps;
-    border?: DivProps;
     switch?: DivProps;
     text?: DivProps;
 }


### PR DESCRIPTION
Masthead now uses React.memo and the css is cleaned up to remove unnecessary rules.