### PR TITLE
Update gallery card solid background to not accept hardcoded colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 8.0.2
+### Changed
+- GalleryCard SolidBackground can no longer receive a color and has a primary and disabled flags to style it properly. To add a specific style you can still pass className.
+
 ## 8.0.1
 ### Changed
 - Moved search input to use accent foreground color

--- a/lib/components/GalleryCard/GalleryCard.module.scss
+++ b/lib/components/GalleryCard/GalleryCard.module.scss
@@ -24,28 +24,25 @@ $card-fixed-content-height: $gallery-card-height - $gallery-card-background-heig
   &:not(:global(.disabled)) {
     &:global(.selected) {
       .card {
+        border: 3px solid var(--color-accent-selected);
         box-shadow: var(--depth-3);
-        border: 3px solid var(--color-accent);
+      }
+
+      &:active,
+      &:focus,
+      &:hover {
+        .card {
+          border-color: var(--color-accent-selected-hover);
+          box-shadow: var(--depth-4);
+        }
       }
     }
 
-    &:not(:global(.selected)):active {
-      .card {
-        border: 1px solid var(--color-accent-selected);
-        box-shadow: var(--depth-4);
-      }
-    }
-
+    &:not(:global(.selected)):active,
+    &:not(:global(.selected)):focus,
     &:not(:global(.selected)):hover {
       .card {
-        border: 1px solid var(--color-accent);
-        box-shadow: var(--depth-4);
-      }
-    }
-
-    &:not(:global(.selected)):focus {
-      .card {
-        border: 1px dashed var(--color-accent);
+        border: 1px solid var(--color-accent-hover);
         box-shadow: var(--depth-4);
       }
     }
@@ -101,11 +98,23 @@ $card-fixed-content-height: $gallery-card-height - $gallery-card-background-heig
   @extend %card-background;
   background-color: var(--color-content-background-primary);
 
-  &.blue {
-    background-color: var(--color-accent-selected);
+  &.primary:not(.disabled) {
+    background-color: var(--color-accent);
 
     span {
-      color: var(--color-accent-foreground)
+      color: var(--color-accent-foreground);
+      fill: var(--color-accent-foreground);
+      stroke: var(--color-accent-foreground);
+    }
+  }
+
+  &.disabled {
+    background-color: var(--color-state-disabled);
+
+    span {
+      color: var(--color-foreground-disabled);
+      fill: var(--color-foreground-disabled);
+      stroke: var(--color-foreground-disabled);
     }
   }
 }

--- a/lib/components/GalleryCard/SolidBackground.tsx
+++ b/lib/components/GalleryCard/SolidBackground.tsx
@@ -3,26 +3,27 @@ import * as classNames from 'classnames/bind';
 import {DivProps, Elements as Attr} from '../../Attributes';
 const css = classNames.bind(require('./GalleryCard.module.scss'));
 
-const defaultColor = '#eaeaea';
-
 export interface SolidBackgroundAttributes {
     container?: DivProps;
 }
 
 export interface SolidBackgroundProps {
     /**
-     * Background color (accepts string color names and RGB hex values)
-     *
-     * Default: #eaeaea
-     */
-    backgroundColor?: string;
-
-    /**
      * Fixed width and height (284 x ?? pixels)
      *
      * Default: true
      */
     fixed?: boolean;
+
+    /**
+     * Indicates if the background should set primary styles (use accent colors)
+     */
+    primary?: boolean;
+
+    /**
+     * Indicates if the background should set disabled styles
+     */
+    disabled?: boolean;
 
     /** Classname to append to top level element */
     className?: string;
@@ -39,26 +40,16 @@ export interface SolidBackgroundProps {
  *
  * @param props Control properties (Defined in `ImageBackgroundProps` interface)
  */
-export const SolidBackground = React.memo((props: SolidBackgroundProps) => {
-    const bgColor = props.backgroundColor ?? defaultColor;
-    const isClass = bgColor ? bgColor.substr(0, 1) !== '#' : false;
-
-    const cls = css(
-        {
-            'background-color': true,
-            'fixed': props.fixed == null || props.fixed,
-            [bgColor]: isClass
-        },
-        props.className
-    );
-
-    const style = isClass 
-        ? { backgroundColor: bgColor }
-        : undefined;
+export const SolidBackground = React.memo(({ fixed, primary, disabled, children, className, attr }: SolidBackgroundProps) => {
+    const cls = css('background-color', { 
+        fixed: fixed == null || fixed, 
+        primary,
+        disabled
+    }, className);
 
     return (
-        <Attr.div className={cls} style={style} attr={props.attr?.container}>
-            {props.children}
+        <Attr.div className={cls} attr={attr?.container}>
+            {children}
         </Attr.div>
     );
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "8.0.1",
+    "version": "8.0.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -249,9 +249,9 @@
             }
         },
         "@microsoft/azure-iot-ux-fluent-css": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/azure-iot-ux-fluent-css/-/azure-iot-ux-fluent-css-8.0.1.tgz",
-            "integrity": "sha512-VjP5ii9+56w58tWsbXgllV4OG0IGqiY0nsh7ivIPZqnONZBV0EyI7oo7Tn+3kNqdGXlWt1iWq+gRJUPdyA7qVg==",
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/azure-iot-ux-fluent-css/-/azure-iot-ux-fluent-css-8.0.3.tgz",
+            "integrity": "sha512-y4oYdgUtp7Nr9TsLoK0hmKRD+bSJ/GA4H1deh2B/su54OwUv1utLE3HIWExxzvMch71MyMY757z26bzjaGZ72A==",
             "requires": {
                 "normalize.css": "^8.0.1"
             }
@@ -4831,7 +4831,8 @@
             "dependencies": {
                 "acorn": {
                     "version": "5.7.3",
-                    "resolved": "",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+                    "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
                     "dev": true
                 },
                 "acorn-jsx": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "8.0.1",
+    "version": "8.0.2",
     "description": "Azure IoT UX Fluent Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
@@ -24,7 +24,7 @@
         "node": ">=12"
     },
     "dependencies": {
-        "@microsoft/azure-iot-ux-fluent-css": "^8.0.1",
+        "@microsoft/azure-iot-ux-fluent-css": "^8.0.3",
         "classnames": "^2.2.5"
     },
     "devDependencies": {


### PR DESCRIPTION
There are a couple of places in renderer that the gallery card is used passing a hardcoded `'blue'` color. This is the only component where we use "blue" as a color instead of using our accent color (which is blue).

Using the hardcoded 'blue' makes this component not respond correctly to white labeling, therefore this PR aims to change it to use `primary` instead and use the correct CSS custom property for coloring.

The user of this component can still pass in a className to provide a custom color if needed, therefore all the current behavior is kept as is.