### PR TITLE
Update checkbox selected/indetermine background when hover instead of foreground

### DIFF
--- a/lib/components/Input/CheckboxInput.module.scss
+++ b/lib/components/Input/CheckboxInput.module.scss
@@ -57,11 +57,9 @@
     &:not(.disabled):not(.indeterminate) .checkbox-checkmark {
         display: inline-block;
     }
-    &.selected:not(.disabled) .checkbox-checkmark {
-        color: var(--color-state-selected-hover);
-    }
-    &.indeterminate:not(.disabled) .checkbox-fill {
-        background-color: var(--color-state-selected-hover);
+    &.selected:not(.disabled) .checkbox-button,
+    &.indeterminate:not(.disabled) .checkbox-button {
+        background-color: var(--color-accent-hover);
     }
 }
 


### PR DESCRIPTION
If we update the foreground when hovering depending on the user's accent color we might have a foreground that is not really visible. Updating the background to an appropriate accent shade is the correct way to avoid this.