### PR TITLE
Make progress use accent color

### DIFF
--- a/lib/components/Loader/HorizontalLoader.module.scss
+++ b/lib/components/Loader/HorizontalLoader.module.scss
@@ -103,7 +103,7 @@
         width: $diameter;
         height: $diameter;
         border-radius: $diameter;
-        background-color: var(--color-foreground-default);
+        background-color: var(--color-accent);
     }
 
     @for $num from 1 through $num-dots {

--- a/lib/components/Loader/Spinner.module.scss
+++ b/lib/components/Loader/Spinner.module.scss
@@ -82,7 +82,7 @@
         width: $diameter;
         height: $diameter;
         border-radius: $diameter;
-        background-color: var(--color-foreground-default);
+        background-color: var(--color-accent);
         margin-left: auto;
         margin-right: auto;
     }


### PR DESCRIPTION
Align loading indicators to use the accent color as the progress indicators in central.