### PR TITLE
Add drop-shadow to search bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 8.0.6
+### Changed
+- Added box-shadow to search bar to be accessible on light mastheads.
+
 ## 8.0.5
 ### Fixed
 - When a FormField was rendered with no error, we were setting the FormError's title to `false`, causing a react warning.

--- a/lib/components/SearchInput/SearchInput.module.scss
+++ b/lib/components/SearchInput/SearchInput.module.scss
@@ -15,7 +15,8 @@ $border-radius-size: $grid-size/2;
     min-width: $search-min-width;
     height: $search-icon-height;
     border-radius: $border-radius-size;
-
+    box-shadow: var(--depth-1);
+    
     .search-input input.input-component:not([value=""]) {
         +button::before {
             display: none;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "8.0.5",
+    "version": "8.0.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -249,9 +249,9 @@
             }
         },
         "@microsoft/azure-iot-ux-fluent-css": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/@microsoft/azure-iot-ux-fluent-css/-/azure-iot-ux-fluent-css-8.0.4.tgz",
-            "integrity": "sha512-j4rpIbS0DhMS+FejELmGVSi9JGn2TTan5szm7XeFaok0fknvYIz2nMhASZBc4IDKWz3cOiI+Eis+YXTwbR2cMQ==",
+            "version": "8.0.6",
+            "resolved": "https://registry.npmjs.org/@microsoft/azure-iot-ux-fluent-css/-/azure-iot-ux-fluent-css-8.0.6.tgz",
+            "integrity": "sha512-5sS7wqYON637bAUflyBEX5xjqPeFcvPG5f1MJ6ezyf8GODTN3hC6SgjOFpRSZCL0vFuJMqDndx/f4LwVudMBFg==",
             "requires": {
                 "normalize.css": "^8.0.1"
             }
@@ -766,7 +766,7 @@
         },
         "camelcase-keys": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
             "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
             "dev": true,
             "requires": {
@@ -2998,7 +2998,7 @@
         },
         "load-json-file": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "dev": true,
             "requires": {
@@ -3011,7 +3011,7 @@
             "dependencies": {
                 "pify": {
                     "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                     "dev": true
                 }
@@ -3146,7 +3146,7 @@
         },
         "meow": {
             "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+            "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
             "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
             "dev": true,
             "requires": {
@@ -3572,7 +3572,7 @@
             "dependencies": {
                 "semver": {
                     "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+                    "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
                     "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
                     "dev": true
                 }
@@ -4249,7 +4249,7 @@
             "dependencies": {
                 "pify": {
                     "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                     "dev": true
                 }
@@ -4839,7 +4839,8 @@
             "dependencies": {
                 "acorn": {
                     "version": "5.7.3",
-                    "resolved": "",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+                    "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
                     "dev": true
                 },
                 "acorn-jsx": {
@@ -5176,7 +5177,7 @@
             "dependencies": {
                 "source-map": {
                     "version": "0.4.4",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                    "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                     "dev": true,
                     "requires": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/azure-iot-ux-fluent-controls",
-    "version": "8.0.5",
+    "version": "8.0.6",
     "description": "Azure IoT UX Fluent Controls",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
@@ -24,7 +24,7 @@
         "node": ">=12"
     },
     "dependencies": {
-        "@microsoft/azure-iot-ux-fluent-css": "^8.0.4",
+        "@microsoft/azure-iot-ux-fluent-css": "^8.0.6",
         "classnames": "^2.2.5"
     },
     "devDependencies": {


### PR DESCRIPTION
In an effort to make white labeled more accessible in every possible masthead color selection it was decided to add a dropshadow to the search bar to make it have more contrast to the masthead background.

This follows the practice that office uses on their search bar and here are some examples of how it looks on different backgrounds:

![shadow normal](https://user-images.githubusercontent.com/2132567/82374942-a5ae4700-99d4-11ea-8f30-bd70e5e5afdb.PNG)
![shadow light](https://user-images.githubusercontent.com/2132567/82374936-a515b080-99d4-11ea-8b05-a9d8ee5c1ef5.PNG)
![shadow red](https://user-images.githubusercontent.com/2132567/82374938-a515b080-99d4-11ea-99ce-d14bbbabdc7f.PNG)
![shadow white](https://user-images.githubusercontent.com/2132567/82374940-a5ae4700-99d4-11ea-9e8a-27fd54f6745c.PNG)
